### PR TITLE
Link to IVPN Privacy Guides

### DIFF
--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -206,6 +206,7 @@ breadcrumb: "VPN"
           <li><a href="/software/networks/">The self-contained networks</a> recommended by Privacy Guides are able to replace a VPN that allows access to services on local area network</li>
           <li><a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">Slicing Onions: Part 1 – Myth-busting Tor</a> by blacklight447</li>
           <li><a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-2-onion-recipes-vpn-not-required">Slicing Onions: Part 2 – Onion recipes; VPN not required</a> by blacklight447</li>
+          <li><a href="https://www.ivpn.net/privacy-guides/">IVPN Privacy Guides</a></li>
         </ol>
       <p>
     </div>


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

We could add a link to IVPN's Privacy Guides. They are very vendor neutral and not written in such a way that seems like it is selling a particular service.

From what I can see, they're a value added feature of their service. They've obviously put time into making sure the information is accurate.

They are also one of our already recommended providers.