### PR TITLE
Right aligned dropdown-menu in nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -23,7 +23,7 @@
           <a class="nav-link dropdown-toggle" href="#" id="providerDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             {{ item.title }}
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             {% for subitem in item.items %}
             {% if subitem.type == "link" %}
             <a class="dropdown-item" href="{% link {{ subitem.file }} %}{%- if subitem.anchor -%}#{{ subitem.anchor }}{%- endif -%}"><span class="{{ subitem.icon | default: "fad fa-file" }} fa-fw"></span> {{ subitem.title }}</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -23,7 +23,7 @@
           <a class="nav-link dropdown-toggle" href="#" id="providerDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             {{ item.title }}
           </a>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
             {% for subitem in item.items %}
             {% if subitem.type == "link" %}
             <a class="dropdown-item" href="{% link {{ subitem.file }} %}{%- if subitem.anchor -%}#{{ subitem.anchor }}{%- endif -%}"><span class="{{ subitem.icon | default: "fad fa-file" }} fa-fw"></span> {{ subitem.title }}</a>


### PR DESCRIPTION
This is to prevent an overflowing dropdown on the right side.

<!-- Submitting a PR? Awesome!! -->

## Description

The dropdown menu is overflowing on the right side of the screen.
<img width="476" alt="image" src="https://user-images.githubusercontent.com/28629647/133296985-27e05a45-503f-473f-b3b8-e3126ba0740a.png">

By end aligning we can fix this, although it is up to you decide if things look like you want them to.

## The fix

By using `dropdown-menu-end` we can align it to the end. [For more information on how to, check out the docs](https://getbootstrap.com/docs/5.0/components/dropdowns/#menu-alignment)
. See screenshot
<img width="482" alt="image" src="https://user-images.githubusercontent.com/28629647/133299043-b6e93842-ca33-40df-8d69-843b28a39b9f.png">

## Alternatives

It's probably possible to have the menu responsive to the size of the screen, with [more information in the Bootstrap docs](https://getbootstrap.com/docs/5.0/components/dropdowns/#responsive-alignment).

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
