### PR TITLE
Update android-addons to mention Work Profile apps

### DIFF
--- a/_includes/legacy/sections/android-addons.html
+++ b/_includes/legacy/sections/android-addons.html
@@ -28,6 +28,6 @@
 
 <ul>
   <li><a href="/providers/dns#dns-android-clients">Our DNS client recommendations</a>, which have information on enabling encrypted DNS on Android.</li>
-  <li><a href="https://github.com/brnhrd/DueProcess">DueProcess</a> - This allows installing apps into a secondary Work Profile, which is an isolated filesystem to compartmentalise these apps from your regular ones. Unlike the similar apps <a href="https://github.com/PeterCxy/Shelter">Shelter/a> and <a href="https://github.com/oasisfeng/island">Island</a>, this additionally includes plausibly deniable encryption to hide these apps on-demand, on a per-app basis or by triggering a so-called lockdown-mode.</li>
+  <li><a href="https://github.com/brnhrd/DueProcess">DueProcess</a> - This allows installing apps into a secondary Work Profile, which is an isolated filesystem to compartmentalise these apps from your regular ones. Unlike the similar apps <a href="https://github.com/PeterCxy/Shelter">Shelter</a> and <a href="https://github.com/oasisfeng/island">Island</a>, this additionally includes plausibly deniable encryption to hide these apps on-demand, on a per-app basis or by triggering a so-called lockdown-mode.</li>
 </ul>
 

--- a/_includes/legacy/sections/android-addons.html
+++ b/_includes/legacy/sections/android-addons.html
@@ -27,7 +27,7 @@
 <h2>See also</h2>
 
 <ul>
-  <li>
-    <a href="/providers/dns#dns-android-clients">Our DNS client recommendations</a>, which have information on enabling encrypted DNS on Android.
-  </li>
+  <li><a href="/providers/dns#dns-android-clients">Our DNS client recommendations</a>, which have information on enabling encrypted DNS on Android.</li>
+  <li><a href="https://github.com/brnhrd/DueProcess">DueProcess</a> - This allows installing apps into a secondary Work Profile, which is an isolated filesystem to compartmentalise these apps from your regular ones. Unlike the similar apps <a href="https://github.com/PeterCxy/Shelter">Shelter/a> and <a href="https://github.com/oasisfeng/island">Island</a>, this additionally includes plausibly deniable encryption to hide these apps on-demand, on a per-app basis or by triggering a so-called lockdown-mode.</li>
 </ul>
+


### PR DESCRIPTION
## Description

I noticed that Work Profile apps aren't on the website yet despite them being commonly used by people seeking greater control over their Android privacy. These apps are especially useful when using apps that require the Files permission to work, as it keeps them from accessing the rest of your personal files. Likewise with Contacts, Calendar, etc. No affiliation with any of these projects, have simply tried them all and they successfully do what they set out to.  