### PR TITLE
Remove "encrypted" header for cloud services

### DIFF
--- a/_includes/legacy/sections/cloud-storage.html
+++ b/_includes/legacy/sections/cloud-storage.html
@@ -1,4 +1,4 @@
-<h2 id="cloud" class="anchor"><a href="#cloud"><i class="fas fa-link anchor-icon"></i></a> Encrypted Cloud Storage Services</h2>
+<h2 id="cloud" class="anchor"><a href="#cloud"><i class="fas fa-link anchor-icon"></i></a>Cloud Storage Services</h2>
 
 <div class="alert alert-warning" role="alert">
   <strong>If you are currently using Dropbox, Google Drive, Microsoft OneDrive or Apple iCloud, you should pick an alternative here.</strong>


### PR DESCRIPTION
## Description

Having "Encrypted" doesn't make any sense as E2EE is still unstable on Nextcloud, especially when it may cause data loss if the user did not backup their files and enabling it without knowing.
