### PR TITLE
Fix Tor link buttons

### DIFF
--- a/_includes/legacy/cardv2.html
+++ b/_includes/legacy/cardv2.html
@@ -94,11 +94,11 @@
           <a
             href="{{include.tor}}"
             rel="noopener"
-            class="btn btn-tor mt-1 me-1"
+            class="btn btn-info mt-1 me-1"
             data-bs-toggle="tooltip"
             data-bs-placement="bottom"
             title="Requires specific software to access: torproject.org">
-            <span class="ptio-tor"></span>
+            <span class="ptio-tor text-light"></span>
           </a>
         {% endif %}
         {% if include.i2p %}


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

In [`cardv2.html`](https://github.com/privacyguides/privacyguides.org/blob/main/_includes/legacy/cardv2.html), there is a class `btn-tor`, which doesn't exist in Bootstrap. It causes the Tor links to appear without a Bootstrap button. It looks like this:
![image](https://user-images.githubusercontent.com/74049394/134290603-92876112-9cda-479d-a38d-2289e7f3da60.png)

I changed `btn-tor` to `btn-info`, which is fixed in [`recommendation-card.html`](https://github.com/privacyguides/privacyguides.org/blob/main/_includes/recommendation-card.html).