### PR TITLE
Small fixes on VPN page

### DIFF
--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -14,7 +14,7 @@ breadcrumb: "VPN"
     <p class="card-text text-danger">If you're looking for added <strong>security</strong>, you should always ensure you're connecting to websites using <a href="/providers/dns/#icanndns">encrypted DNS</a> and <a href="https://en.wikipedia.org/wiki/HTTPS">HTTPS</a>. A VPN is not a replacement for good security practices.</p>
     <p class="card-text text-info">If you're looking for additional <strong>privacy</strong> from your ISP, on a public Wi-Fi network, or while torrenting files, a VPN may be the solution for you as long as you understand <a href="#info">the risks involved</a>.</p>
     <a href="https://www.torproject.org/" class="btn btn-danger">Download Tor</a>
-    <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor" class="btn btn-outline-danger">Tor Myths &amp; FAQ</a>
+    <a href="https://medium.com/privacyguides/slicing-onions-part-1-myth-busting-tor-9ec188ae1904" class="btn btn-outline-danger">Tor Myths &amp; FAQ</a>
     <a href="#info" class="btn btn-outline-info">More Info</a>
   </div>
 </div>
@@ -204,7 +204,7 @@ breadcrumb: "VPN"
           <li><a href="https://schub.io/blog/2019/04/08/very-precarious-narrative.html">VPN - a Very Precarious Narrative</a> by Dennis Schubert</li>
           <li><a href="https://gist.github.com/joepie91/5a9909939e6ce7d09e29">Don't use VPN services</a> by Sven Slootweg</li>
           <li><a href="/software/networks/">The self-contained networks</a> recommended by Privacy Guides are able to replace a VPN that allows access to services on local area network</li>
-          <li><a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">Slicing Onions: Part 1 – Myth-busting Tor</a> by blacklight447</li>
+          <li><a href="https://medium.com/privacyguides/slicing-onions-part-1-myth-busting-tor-9ec188ae1904">Slicing Onions: Part 1 – Myth-busting Tor</a> by blacklight447</li>
           <li><a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-2-onion-recipes-vpn-not-required">Slicing Onions: Part 2 – Onion recipes; VPN not required</a> by blacklight447</li>
           <li><a href="https://www.ivpn.net/privacy-guides/">IVPN Privacy Guides</a></li>
         </ol>

--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -222,7 +222,6 @@ breadcrumb: "VPN"
 
         <ul>
           <li><a href="https://blog.privacytools.io/the-trouble-with-vpn-and-privacy-reviews/">The Trouble with VPN and Privacy Review Sites</a></li>
-          <li><a href="https://vikingvpn.com/blogs/off-topic/beware-of-vpn-marketing-and-affiliate-programs">Beware of False Reviews - VPN Marketing and Affiliate Programs</a></li>
           <li><a href="https://torrentfreak.com/proxy-sh-vpn-provider-monitored-traffic-to-catch-hacker-130930/">Proxy.sh VPN Provider Sniffed Server Traffic to Catch Hacker</a></li>
           <li><a href="https://www.ivpn.net/privacy">IVPN.net will collect your email and IP address after sign up</a><br />Read the <a data-bs-toggle="tooltip" data-bs-placement="top" title="The IP collected at signup is only used for a few seconds by our fraud module and then discarded, it is not stored. Storing them would significantly increase our own liability and certainly would not be in our interest. You're absolutely welcome to signup using Tor or a VPN.">Email statement</a> from IVPN.</li>
           <li><a href="https://medium.com/@blackVPN/no-logs-6d65d95a3016">blackVPN announced to delete connection logs after disconnection</a></li>

--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -221,7 +221,7 @@ breadcrumb: "VPN"
         <h3>Related VPN information</h3>
 
         <ul>
-          <li><a href="https://blog.privacytools.io/the-trouble-with-vpn-and-privacy-reviews/">The Trouble with VPN and Privacy Review Sites</a></li>
+          <li><a href="https://medium.com/privacyguides/the-trouble-with-vpn-and-privacy-review-sites-ae9b29eda8fd">The Trouble with VPN and Privacy Review Sites</a></li>
           <li><a href="https://torrentfreak.com/proxy-sh-vpn-provider-monitored-traffic-to-catch-hacker-130930/">Proxy.sh VPN Provider Sniffed Server Traffic to Catch Hacker</a></li>
           <li><a href="https://www.ivpn.net/privacy">IVPN.net will collect your email and IP address after sign up</a><br />Read the <a data-bs-toggle="tooltip" data-bs-placement="top" title="The IP collected at signup is only used for a few seconds by our fraud module and then discarded, it is not stored. Storing them would significantly increase our own liability and certainly would not be in our interest. You're absolutely welcome to signup using Tor or a VPN.">Email statement</a> from IVPN.</li>
           <li><a href="https://medium.com/@blackVPN/no-logs-6d65d95a3016">blackVPN announced to delete connection logs after disconnection</a></li>
@@ -231,7 +231,7 @@ breadcrumb: "VPN"
             {% include badge.html
             color="warning"
             icon="fas fa-exclamation-triangle"
-            link="https://blog.privacytools.io/the-trouble-with-vpn-and-privacy-reviews"
+            link="https://medium.com/privacyguides/the-trouble-with-vpn-and-privacy-review-sites-ae9b29eda8fd"
             tooltip="This site has affiliate based recommendations. They get paid for referring visitors to specific VPN providers."
             text="Affiliate program"
             %}
@@ -241,7 +241,7 @@ breadcrumb: "VPN"
             {% include badge.html
             color="warning"
             icon="fas fa-exclamation-triangle"
-            link="https://blog.privacytools.io/the-trouble-with-vpn-and-privacy-reviews"
+            link="https://medium.com/privacyguides/the-trouble-with-vpn-and-privacy-review-sites-ae9b29eda8fd"
             tooltip="This site has affiliate based recommendations. They get paid for referring visitors to specific VPN providers."
             text="Affiliate program"
             %}
@@ -251,7 +251,7 @@ breadcrumb: "VPN"
             {% include badge.html
             color="warning"
             icon="fas fa-exclamation-triangle"
-            link="https://blog.privacytools.io/the-trouble-with-vpn-and-privacy-reviews"
+            link="https://medium.com/privacyguides/the-trouble-with-vpn-and-privacy-review-sites-ae9b29eda8fd"
             tooltip="This site has affiliate based recommendations. They get paid for referring visitors to specific VPN providers."
             text="Affiliate program"
             %}

--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -152,7 +152,7 @@ breadcrumb: "VPN"
       <p><strong>Best Case:</strong></p>
       <p>Responsible marketing that is both educational and useful to the consumer could include:</p>
       <ul>
-        <li>A accurate comparison to when Tor or other <a href="/software/networks/">Self networks</a> should be used.</li>
+        <li>A accurate comparison to when Tor or other <a href="/software/networks/">Self-contained networks</a> should be used.</li>
         <li>Availability of the VPN provider's website over a .onion <a href="https://en.wikipedia.org/wiki/.onion">Hidden Service</a></li>
       </ul>
     </div>

--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -152,7 +152,7 @@ breadcrumb: "VPN"
       <p><strong>Best Case:</strong></p>
       <p>Responsible marketing that is both educational and useful to the consumer could include:</p>
       <ul>
-        <li>A accurate comparison to when Tor or other <a href="https://www.privacytools.io/software/networks/">Self contained networks</a> should be used.</li>
+        <li>A accurate comparison to when Tor or other <a href="/software/networks/">Self networks</a> should be used.</li>
         <li>Availability of the VPN provider's website over a .onion <a href="https://en.wikipedia.org/wiki/.onion">Hidden Service</a></li>
       </ul>
     </div>

--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -142,7 +142,7 @@ breadcrumb: "VPN"
           <li>Making guarantees of protecting anonymity 100%. When someone makes a claim that something is 100% it means there is no certainty for failure. We know users can quite easily deanonymize themselves in a number of ways, eg:</li>
           <ul>
             <li>Reusing personal information eg. (email accounts, unique pseudonyms etc) that they accessed without anonymity software (Tor, VPN etc)</li>
-            <li><a href="https://www.privacytools.io/browsers/#fingerprint">Browser fingerprinting</a></li>
+            <li><a href="/browsers/#fingerprint">Browser fingerprinting</a></li>
           </ul>
           <li>Claim that a single circuit VPN is "more anonymous" than Tor, which is a circuit of 3 or more hops that regularly changes.</li>
           <li>Use responsible language, eg it is okay to say that a VPN is "disconnected" or "not connected", however claiming that a user is "exposed", "vulnerable" or "compromised" is needless use of alarming language that may be incorrect. For example the visiting user might be on another VPN provider's service or using Tor.</li>


### PR DESCRIPTION
1. Links pointing to pt.io pages changed to root-related
2. Blog links changed to medium.com Privacy Guides version where possible
3. Link to VikingVPN blog post removed (404, provider defunct)

Community disclaimer: I'm part of the IVPN team, but I add suggestions to PrivacyGuides pages in a personal capacity. To avoid conflict of interest I'm not suggesting changes to VPN recommendation sections and will not include links to IVPN related projects.