### PR TITLE
Add deprecation warning in HTTPS Everywhere

### DIFF
--- a/_includes/legacy/sections/browser-addons.html
+++ b/_includes/legacy/sections/browser-addons.html
@@ -21,6 +21,7 @@
   title="HTTPS Everywhere: Secure Connections"
   image="/assets/img/legacy_svg/3rd-party/https_everywhere.svg"
   description="<strong>HTTPS Everywhere</strong> enables encryption of your connections to many major websites, making your browsing more secure. It is a collaboration between The Tor Project and the Electronic Frontier Foundation."
+  labels="color==warning::link==https://www.eff.org/deeplinks/2021/09/https-actually-everywhere::text==Deprecation warning::tooltip==EFF will deprecate this extension in 2022."
   website="https://www.eff.org/https-everywhere"
   privacy-policy="https://www.eff.org/code/privacy/policy"
   github="https://github.com/EFForg/https-everywhere"


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Added a warning label in HTTPS Everywhere. Hovering over it will bring up a tooltip stating that `EFF will deprecate this extension in 2022.`

I think this partially resolves #145.