### PR TITLE
Include Proton Drive for Cloud Storage

### DIFF
--- a/_includes/legacy/sections/cloud-storage.html
+++ b/_includes/legacy/sections/cloud-storage.html
@@ -1,4 +1,4 @@
-<h2 id="cloud" class="anchor"><a href="#cloud"><i class="fas fa-link anchor-icon"></i></a> Encrypted Cloud Storage Services</h2>
+<h2 id="cloud" class="anchor"><a href="#cloud"><i class="fas fa-link anchor-icon"></i></a> Cloud Storage Services</h2>
 
 <div class="alert alert-warning" role="alert">
   <strong>If you are currently using Dropbox, Google Drive, Microsoft OneDrive or Apple iCloud, you should pick an alternative here.</strong>
@@ -27,4 +27,13 @@
 <ul>
   <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.</li>
   <li><a href="https://cryptpad.fr">CryptPad</a> - Free and end-to-end encrypted real time collaboration sharing folders, media, and documents.</li>
+  <li><a href="https://drive.protonmail.com">Proton Drive</a>
+        <a href="https://protonmail.com/blog/proton-drive-early-access/"
+            class="text-decoration-none link-warning"
+            data-bs-toggle="tooltip" title=""
+            data-bs-original-title="">
+            <i class="fad fa-question-circle">
+            </i> Beta
+        </a>
+      - End-to-end encrypted general file storage hosted in Switzerland.</li>
 </ul>


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Proposes adding Proton Drive as possible privacy-respecting cloud storage. Though the feature is still in beta, it already supports encrypted files as well as sharing and previewing in the browser.

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->

All this edit does is add a small bullet-point mentioning ProtonMail's foray into encrypted file storage.