### PR TITLE
remove startpage search engine

### DIFF
--- a/_includes/legacy/sections/search-engines.html
+++ b/_includes/legacy/sections/search-engines.html
@@ -35,14 +35,6 @@
   github="https://github.com/Qwant/"
 %}
 
-{% include legacy/cardv2.html
-  title="Startpage.com"
-  image="/assets/img/legacy_svg/3rd-party/startpage.svg"
-  description='Startpage.com is a search engine that provides Google search results with complete privacy protection. <span class="flag-icon flag-icon-nl"></span> Startpage BV is a Netherlands-based company that has been dedicated to privacy-respecting search since 2006.'
-  labels="color==warning::link==https://support.startpage.com/index.php?/Knowledgebase/Article/View/1277/0/startpage-ceo-robert-beens-discusses-the-investment-from-privacy-one--system1::text==Warning::tooltip==Startpage.com was recently acquired by United States-based System1."
-  website="https://www.startpage.com/"
-  privacy-policy="https://www.startpage.com/en/privacy-policy/"
-%}
 
 <h3>Worth Mentioning</h3>
 


### PR DESCRIPTION
Hello,
IMHO it's time we remove startpage from search engine recommendations.

It's been [bought by a marketing firm](https://www.youtube.com/watch?v=QaG3pqSo8lY)
