### PR TITLE
🧅 Add Cloudflare DNS onion protocol

### DIFF
--- a/_data/dns/cloudflare.yml
+++ b/_data/dns/cloudflare.yml
@@ -16,7 +16,7 @@ logs:
     The 1.1.1.1 resolver service does not log personal data,
     and the bulk of the limited non-personally identifiable query data is only stored for 25 hours."
 protocols:
-  - name: Onion
+  - name: DNS over HTTPS over Tor
   - name: DoH
   - name: DoT
 dnssec: true

--- a/_data/dns/cloudflare.yml
+++ b/_data/dns/cloudflare.yml
@@ -16,6 +16,7 @@ logs:
     The 1.1.1.1 resolver service does not log personal data,
     and the bulk of the limited non-personally identifiable query data is only stored for 25 hours."
 protocols:
+  - name: Onion
   - name: DoH
   - name: DoT
 dnssec: true


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Resolves #239

This is no recommendation of using cloudflare, just existing protocol list addition.
 Source: [(DNS over TCP, TLS, and HTTPS) over Onion](https://developers.cloudflare.com/1.1.1.1/other-ways-to-use-1.1.1.1/dns-over-tor#dns-over-tcp-tls-and-https)

![https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/dns-query](https://blog.cloudflare.com/content/images/2018/06/tor.gif)
![tor.cloudflare-dns.com](https://blog.cloudflare.com/content/images/2018/05/image_5.png)
