### PR TITLE
Invidio.us has been replaced by Invidious.io... a year ago

### DIFF
--- a/_includes/legacy/sections/video-frontends.html
+++ b/_includes/legacy/sections/video-frontends.html
@@ -9,7 +9,7 @@
   image="/assets/img/legacy_svg/3rd-party/invidious.svg"
   description='Invidious is an alternative front-end to YouTube. It is free software, with no advertising or Javascript dependency to play videos, with lots of other features that allow you to have a complete YouTube experience, sans Google.'
   labels="color==warning::icon==fas fa-exclamation-triangle::link==https://github.com/iv-org/documentation/blob/master/Always-use-%22local%22-to-proxy-video-through-the-server-without-creating-an-account.md::text==Warning::tooltip==By default, Invidious will not proxy videos through the instance's proxy."
-  website="https://invidio.us"
+  website="https://invidious.io"
   github="https://github.com/iv-org/invidious"
-  web="https://instances.invidio.us"
+  web="https://instances.invidious.io"
 %}


### PR DESCRIPTION
The invidio.us instance has been dead for more than a year now, we moved to a new domain almost 1 year ago, in January... yet you never updated the link.

You are still sending thousands of users to a domain we don't own (we just control it) and that have been kept alive - as a redirect - because a ton of people - including you - still link to it because they never update their stuff.

Please, can you at least use what you recommend (because this shows that you obviously don't) or at the very least CHECK that the link aren't dead and/or haven't moved?!

Thank you.