### PR TITLE
Change 'Video Streaming' icon

### DIFF
--- a/_data/nav/3_software.yml
+++ b/_data/nav/3_software.yml
@@ -54,5 +54,5 @@ items:
     file: legacy_pages/software/networks.html
   - type: link
     title: Video Streaming
-    icon: fab fa-youtube
+    icon: fad fa-video
     file: _evergreen/video-streaming.html


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

In the navbar, the icon of `Video Streaming` (under `Software`) is currently the YouTube's logo.
I changed it to a generic video icon.

Additionally, it is a duotone icon that blends well with others.