### PR TITLE
Remove mastodon-simplified-federation

### DIFF
--- a/legacy_pages/providers/social-networks.html
+++ b/legacy_pages/providers/social-networks.html
@@ -9,7 +9,6 @@ description: "Find a social network that doesn't pry into your data or monetize 
 
 <h3>Related Information</h3>
 <ul>
-  <li><a href="https://addons.mozilla.org/firefox/addon/mastodon-simplified-federation/">Mastodon: Simplified Federation</a> - Firefox Extension to improve usability for remote Mastodon instances.</li>
   <li><a href="https://justdeleteme.xyz/">JustDeleteMe</a> - A directory of direct links to delete your account from web services.</li>
   <li><a href="https://forget.codl.fr/">Forget</a> - A service that automatically deletes your old posts on Twitter and Mastodon that everyone has forgotten about.</li>
 </ul>


### PR DESCRIPTION
## Description

We're moving away from recommending extensions in general. This extension hasn't been updated for a long time and was never evaluated for privacy or security.