### PR TITLE
Change 'View on GitHub' to 'Edit on GitHub'

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -25,6 +25,6 @@
     </nav>
   </div>
   <div class="ps-3">
-    <a class="btn btn-outline-gray" href="https://github.com/privacyguides/privacyguides.org/edit/main/{%- if page.collection -%}collections/{%- endif -%}{{ page.path }}" role="button"><i class="fad fa-fw fa-pencil-alt"></i> View on GitHub</a>
+    <a class="btn btn-outline-gray" href="https://github.com/privacyguides/privacyguides.org/edit/main/{%- if page.collection -%}collections/{%- endif -%}{{ page.path }}" role="button"><i class="fad fa-fw fa-pencil-alt"></i> Edit on GitHub</a>
   </div>
 </div>


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Since the link goes to the editor and it has a pencil icon next to it, 'Edit on GitHub' seems more appropriate.

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
