### PR TITLE
Fixing typo of recipient on line 11

### DIFF
--- a/_data/software/messengers/1_signal.yml
+++ b/_data/software/messengers/1_signal.yml
@@ -8,7 +8,7 @@ description: |
 
   All communications are E2EE. Contact lists are encrypted using your login PIN and the server does not have access to it. Personal profiles are also encrypted and only shared with contacts who add you.
 
-  Signal has minimal metadata when <a href="https://signal.org/blog/sealed-sender/">Sealed Sender</a> is enabled. The sender address is encrypted along with the message body, and only the reciepient address is visible to the server.
+  Signal has minimal metadata when <a href="https://signal.org/blog/sealed-sender/">Sealed Sender</a> is enabled. The sender address is encrypted along with the message body, and only the recipient address is visible to the server.
 
   <h4>Notes</h4>
     <p>Signal requires your phone number as a personal identifier.</p>


### PR DESCRIPTION
Line 11 changed "reciepient" to "recipient" to fix typo.