### PR TITLE
Startmail domains for non-business accounts

### DIFF
--- a/_includes/legacy/sections/email-providers.html
+++ b/_includes/legacy/sections/email-providers.html
@@ -175,7 +175,7 @@
     <p><strong><a href="https://startmail.com">StartMail.com</a></strong> is an email service with a focus on security and privacy through the use of standard OpenPGP encryption. StartMail has been in operation since <strong>2014</strong> and is based in Boulevard 11, Zeist <span class="flag-icon flag-icon-nl"></span> Netherlands. Accounts start with 10GB. They offer a 30-day trial.</p>
 
     <h5>{% include badge.html color="success" text="Domains and Aliases" %}</h5>
-    <p>Personal accounts can use <a href="https://support.startmail.com/hc/en-us/articles/360007297457-Aliases">Custom or Generated</a> aliases. Business accounts can use <a href="https://support.startmail.com/hc/en-us/articles/360006840058">Domain aliases</a>.</p>
+    <p>Personal accounts can use <a href="https://support.startmail.com/hc/en-us/articles/360007297457-Aliases">Custom or Quick</a> aliases. <a href="https://support.startmail.com/hc/en-us/articles/4403911432209-Setup-a-custom-domain">Custom domains</a> are also available.</p>
 
     <h5>{% include badge.html color="warning" text="Payment Methods" %}</h5>
     <p>StartMail accepts Visa, MasterCard, American Express and Paypal. StartMail also has other <a href="https://support.startmail.com/hc/en-us/articles/360006620637-Payment-methods">payment options</a> such as Bitcoin (currently only for Personal accounts) and SEPA Direct Debit for accounts older than a year.</p>


### PR DESCRIPTION
Startmail domains are now available to non-business customers.

The [previous article](https://web.archive.org/web/20211120045059/https://support.startmail.com/hc/en-us/articles/360006840058) seems to be now deleted.

https://deploy-preview-528--privacyguides.netlify.app/providers/email/#startmail