### PR TITLE
add zulucrypt

### DIFF
--- a/_includes/legacy/sections/file-encryption.html
+++ b/_includes/legacy/sections/file-encryption.html
@@ -43,4 +43,5 @@
   <li><a href="https://www.dyne.org/software/tomb/">Tomb</a> - A simple zsh script for making LUKS containers on the commandline.</li>
   <li><a href="https://hat.sh/">Hat.sh</a> - A web application that provides secure client-side file encryption in your browser. It can also be selfhosted.</li>
   <li><a href="https://www.kryptor.co.uk/">Kryptor</a> - Free and open source file encryption software for Windows, macOS, and Linux.</li>
+  <li><a href="https://github.com/mhogomchungu/zuluCrypt">Zulucrypt</a> - a front end to cryptsetup and tcplay, which allows easy management of encrypted block devices.</li>
 </ul>


### PR DESCRIPTION
https://github.com/mhogomchungu/zuluCrypt
description based on the github project description

<!-- Submitting a PR? Awesome!! -->

## Description

Resolves: no issue opened <!-- Did you solve an open GitHub issue? Put the number here so we mark it complete! -->

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
I am adding a software recommendation: zulucrypt. It is a tool for creating encrypted containers. The website linked is the github repo https://github.com/mhogomchungu/zuluCrypt. It also seems to have an official website https://mhogomchungu.github.io/zuluCrypt/, which is easy to find from the github repo. The tool is similar to tomb (which is already recommended), but it does more from what I can see. It definitely seems like a tool more suited for advanced users, but I see no harm in including an extra recommendation.

You might also be interested on the whonix wiki's opinion on it:
https://www.whonix.org/wiki/Full_Disk_Encryption#Zulucrypt

I have no conflict of interest.