### PR TITLE
FramaDrop warning removed

### DIFF
--- a/_includes/legacy/sections/file-sharing.html
+++ b/_includes/legacy/sections/file-sharing.html
@@ -36,7 +36,6 @@
     color="warning"
     icon="fas fa-exclamation-triangle"
     link="https://framasoft.org/en/cgu/"
-    tooltip="FramaDrop logs IP addresses and fingerprints the browser for an unclear amount of time."
     %}
   </li>
   <li><a href="https://github.com/schollz/croc">croc</a> - Easily and securely send arbitrary-sized files from one computer to another. Similar to Magic Wormhole but without dependencies.</li>

--- a/_includes/legacy/sections/file-sharing.html
+++ b/_includes/legacy/sections/file-sharing.html
@@ -31,13 +31,7 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://framadrop.org/">FramaDrop</a> - Stores a file of any size for 24h. Data is end-to-end encrypted from your browser, powered by <a href="https://framagit.org/fiat-tux/hat-softwares/lufi">LuFi</a>.
-    {% include badge.html
-    color="warning"
-    icon="fas fa-exclamation-triangle"
-    link="https://framasoft.org/en/cgu/"
-    %}
-  </li>
+  <li><a href="https://framadrop.org/">FramaDrop</a> - Stores a file of any size for 24h. Data is end-to-end encrypted from your browser, powered by <a href="https://framagit.org/fiat-tux/hat-softwares/lufi">LuFi</a>.</li>
   <li><a href="https://github.com/schollz/croc">croc</a> - Easily and securely send arbitrary-sized files from one computer to another. Similar to Magic Wormhole but without dependencies.</li>
   <li><a href="https://freedombox.org/">FreedomBox</a> - Designed to be your own inexpensive server at home. It runs free software and offers an increasing number of services ranging from a calendar or XMPP server, to a wiki, or VPN.</li>
 </ul>


### PR DESCRIPTION
The service no longer exists, as seen at the URL, so warning about its logging is no longer necessary.