### PR TITLE
Add a warning for CalyxOS

### DIFF
--- a/collections/_evergreen/android.html
+++ b/collections/_evergreen/android.html
@@ -7,6 +7,10 @@ description: "Android is a secure operating system that has strong <a href='http
 The main privacy concern with most Android devices is that they usually include <a href='https://developers.google.com/android/guides/overview'>Google Play Services</a>. This component is proprietary, closed source, has a privileged role on your phone and may collect private user information. It is not a part of the <a href='https://source.android.com/'>Android Open Source Project (AOSP)</a> nor is it included with the below derivatives."
 ---
 
+<div class="alert alert-warning" role="alert">
+  <strong>While CalyxOS still listed on our website, we do not recommend installing it in its current state. The distribution has fallen quite far behind on security updates - firmware patch level is still on the October 2021 patch on the stable and beta branches, and the Chromium browser/webview is still on version 95.0.4638.50 from October 2021 with over 100 known vulnerabilities on all branches.</strong>
+</div>
+
 <h2 id="mobile-only-recommendations" class="anchor">
     <a href="#aosp-derivatives"><i class="fas fa-link anchor-icon"></i></a>
     AOSP Derivatives


### PR DESCRIPTION
I don't want to completely remove CalyxOS just yet, but we really cannot recommend it in its current state. The firmware patch level is 4 months out of date on both the stable and beta branch (yes, I am aware that it is fixed on the testing branch), and Chromium browser & webview are completely outdated on all branches. https://github.com/privacyguides/privacyguides.org/pull/548#issuecomment-1018245074. 

I'd like to give them the benefit of the doubt and wait a bit longer to see how things work out, but in its current state, I don't think Calyx is a good recommendation anymore.