### PR TITLE
Reverting commit 78f69ad

### DIFF
--- a/collections/_evergreen/android.html
+++ b/collections/_evergreen/android.html
@@ -8,7 +8,7 @@ The main privacy concern with most Android devices is that they usually include 
 ---
 
 <div class="alert alert-warning" role="alert">
-  <strong>While CalyxOS still listed on our website, we do not recommend installing it in its current state. The distribution has fallen quite far behind on security updates - firmware patch level is still on the October 2021 patch on the stable branch, and the Chromium browser/webview is still on version 95.0.4638.50 from October 2021 with over 100 known vulnerabilities on all branches.</strong>
+  <strong>While CalyxOS still listed on our website, we do not recommend installing it in its current state. The distribution has fallen quite far behind on security updates - firmware patch level is still on the October 2021 patch on the stable and beta branches, and the Chromium browser/webview is still on version 95.0.4638.50 from October 2021 with over 100 known vulnerabilities on all branches.</strong>
 </div>
 
 <h2 id="mobile-only-recommendations" class="anchor">


### PR DESCRIPTION
Originally I removed the mention of the beta branch in the warning because someone linked me the post on Calyx's website about Android 12 being in Beta https://calyxos.org/news/2022/01/19/android-12-changelog/

It is not. Apparently, the update servers says otherwise. Here are a few examples:

https://release.calyxinstitute.org/barbet-beta
https://release.calyxinstitute.org/barbet-testing
https://release.calyxinstitute.org/redfin-beta
https://release.calyxinstitute.org/redfin-testing

<img width="514" alt="Screen Shot 2022-01-26 at 8 28 22 AM" src="https://user-images.githubusercontent.com/57488583/151171448-bed47712-0fdf-4756-9957-61e44da28029.png">

<img width="605" alt="Screen Shot 2022-01-26 at 8 28 50 AM" src="https://user-images.githubusercontent.com/57488583/151171534-11b46d5e-93be-4324-96e5-f3f81d87a52a.png">

The beta branch is still on Android 11 despite of what that post says. Only the testing branch is on Android 12. 

If you look at the pixel 6 series:
https://release.calyxinstitute.org/raven-beta
https://release.calyxinstitute.org/oriole-beta

<img width="814" alt="Screen Shot 2022-01-26 at 8 31 25 AM" src="https://user-images.githubusercontent.com/57488583/151171900-b2089d5b-6a3e-454d-9aaf-16a8a542c960.png">

They don't exist on the beta branch right now. Only the testing branch.

I guess I should have checked before making the commit. I should have also realized the CalyxOS post was on the 01/19, before I even added the warning banner. But honestly, they should have made it clear that it's an experimental testing build and not an actual build on the beta channel.