### PR TITLE
add Haven social network

### DIFF
--- a/_includes/legacy/sections/social-networks.html
+++ b/_includes/legacy/sections/social-networks.html
@@ -46,6 +46,15 @@
 %}
 
 {% include legacy/cardv2.html
+  title="Haven - Facebook Alternative"
+  image="/assets/img/legacy_svg/3rd-party/haven.svg"
+  description="Haven is a self-hostable private blog server.  It includes user management in the Web UI; it publishes HTML and private RSS feeds for aggregation.  It also includes a build-in feed reader.  It uses RSS to to share content with other Haven instances but is compatible with web browsers and feed readers for users who do not have their own Haven.  FOSS, MIT-license".
+  website="https://havenweb.org/"
+  github="https://github.com/havenweb/haven/"
+  web="https://havenweb.org/"
+%}
+
+{% include legacy/cardv2.html
   title="PixelFed - Instagram Alternative"
   image="/assets/img/legacy_svg/3rd-party/pixelfed.svg"
   description='PixelFed is a free and ethical photo sharing platform, powered by ActivityPub federation. Pixelfed is an open-source, federated platform. You can run your own instance or <a href="https://fediverse.party/en/pixelfed/">join an existing one.</a>'

--- a/_includes/legacy/sections/social-networks.html
+++ b/_includes/legacy/sections/social-networks.html
@@ -48,7 +48,7 @@
 {% include legacy/cardv2.html
   title="Haven - Facebook Alternative"
   image="/assets/img/legacy_svg/3rd-party/haven.svg"
-  description="Haven is a self-hostable private blog server.  It includes user management in the Web UI; it publishes HTML and private RSS feeds for aggregation.  It also includes a build-in feed reader.  It uses RSS to to share content with other Haven instances but is compatible with web browsers and feed readers for users who do not have their own Haven.  FOSS, MIT-license".
+  description="Haven is a self-hostable private blog server.  It includes user management in the Web UI; it publishes HTML and private RSS feeds for aggregation.  It also includes a build-in feed reader.  It uses RSS to to share content with other Haven instances but is compatible with web browsers and feed readers for users who do not have their own Haven.  FOSS, MIT-license"
   website="https://havenweb.org/"
   github="https://github.com/havenweb/haven/"
   web="https://havenweb.org/"

--- a/assets/img/legacy_svg/3rd-party/haven.svg
+++ b/assets/img/legacy_svg/3rd-party/haven.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="105.65mm" height="105.67mm" version="1.1" viewBox="0 0 374.33677 374.41449" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(-170.83 -152.5)" fill="none" stroke="#0366d6" stroke-linecap="round" stroke-width="50">
+<path d="m282.84 185.65v308.11"/>
+<path d="m433.36 493.75v-135.36c0-47.901-40.302-79.752-84.348-63.462-34.534 12.772-66.165 59.912-66.165 59.912"/>
+</g>
+</svg>


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Resolves: # <!-- Did you solve an open GitHub issue? Put the number here so we mark it complete! -->

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->

Adding Haven to social networks.
 Haven is FOSS, self-hostable, and fully aligned with the goals of privacyguides.org (in my opinion)
Github: https://github.com/havenweb/haven/
Website: https://havenweb.org
Conflict of interest: Haven is my project, I offer paid hosting. 