### PR TITLE
Adding Advanced Protection Program

### DIFF
--- a/collections/_evergreen/android.md
+++ b/collections/_evergreen/android.md
@@ -148,7 +148,23 @@ We have these general tips:
 * Check if an app is available on the [IzzyOnDroid](https://apt.izzysoft.de/fdroid/) repository. The IzzyOnDroid repository pulls builds directly from GitHub and is the next best thing to the developers' own repositories. We recommend that you download the GitHub builds and install them manually first, then use IzzyOnDroid for any subsequent updates. This will ensure that the signature of the applications you get from IzzyOnDroid matches that of the developer and the packages have not been tampered with.
 * Check if there are any differences between the F-Droid version and the Google Play Store version. Some applications like [IVPN](https://www.ivpn.net/) do not include certain features (eg [AntiTracker](https://www.ivpn.net/knowledgebase/general/antitracker-faq/)) in their Google Play Store build out of fear of censorship by Google.
 
-Evaluate whether the additional features in the F-Droid build is worth the slower updates or whether faster updates from the Google Play is worth the potential privacy issues in your [threat model](/threat-modeling/).
+Evaluate whether the additional features in the F-Droid build are worth the slower updates. Also think about whether faster updates from the Google Play Store are worth the potential privacy isues in your [threat model](/threat-modeling/).
+
+## Advanced Protection Program
+If you have a Google account we suggest enrolling in the [Advanced Protection Program](https://landing.google.com/advancedprotection/). It is available at no cost to anyone with two or more hardware security keys with [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) support.
+
+The Advanced Protection Program provides enhanced threat monitoring and enables:
+
+* Stricter two factor authentication; e.g. that [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) **must** be used and disallows the use of [SMS OTPs](https://en.wikipedia.org/wiki/One-time_password#SMS), [TOTP](https://en.wikipedia.org/wiki/Time-based_one-time_password), and [OAuth](https://en.wikipedia.org/wiki/OAuth).
+* Only Google and verified third party apps can access account data
+* Scanning of incoming emails on Gmail accounts for [phishing](https://en.wikipedia.org/wiki/Phishing#Email_phishing) attempts
+* Stricter [safe browser scanning](https://www.google.com/chrome/privacy/whitepaper.html#malware) with Google Chrome
+* Stricter recovery process for accounts with lost credentials
+
+For users that are using the privileged Play Services (common on stock operating systems), the Advanced Protection Program also comes with [additional benefits](https://support.google.com/accounts/answer/9764949?hl=en) such as:
+* Not allowing app installation outside of the Google Play Store, the OS vendor's app store, or via [`adb`](https://en.wikipedia.org/wiki/Android_Debug_Bridge)
+* Mandatory automatic device scanning with [Play Protect](https://support.google.com/googleplay/answer/2812853?hl=en#zippy=%2Chow-malware-protection-works%2Chow-privacy-alerts-work)
+* Warning the user about unverified applications
 
 ## Security comparison of GrapheneOS and CalyxOS
 


### PR DESCRIPTION
Adding this to the Android page for now, as it does affect stock Android. When we discuss ChromeOS/ChromeOS Flex, or other Google products, we could consider making a page dedicated to recommendations with the Google Account and linking to that page instead.