### PR TITLE
DuckDuckGo Correction

### DIFF
--- a/_data/providers/search-engines/1_duckduckgo.yml
+++ b/_data/providers/search-engines/1_duckduckgo.yml
@@ -6,7 +6,7 @@ description: |
 
   DuckDuckGo has a [lite](https://duckduckgo.com/lite) and [html](https://duckduckgo.com/html) only version, both of which [do not require JavaScript](https://help.duckduckgo.com/features/non-javascript) and can be used with their [Tor onion address](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion) (append [/lite](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/lite) or [/html](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/html) for the respective version).
 
-  DuckDuckGo uses its own crawler and various [other sources](https://help.duckduckgo.com/results/sources) to provide its search data.
+  DuckDuckGo uses a commercial Bing API and various [other sources](https://help.duckduckgo.com/results/sources) to provide its search data.
 
   #### Notes
   The company is based in the <span class="flag-icon flag-icon-us"></span> USA.


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

Changed the description of DuckDuckGo to indicate that the results are [from Bing](https://help.duckduckgo.com/results/sources/), not its own crawler.

Resolves: #699