### PR TITLE
JSON feed for blog posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,6 +25,10 @@
     {{ site.data.schema.organization | jsonify }}
   </script>
 
+  <!-- blog feeds -->
+  <link rel="alternate" title="Blog (JSON feed)" type="application/json" href="/feed.json" />
+  <link rel="alternate" title="Blog (Atom feed)" type="application/rss+xml" href="/feed.xml" />
+
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/layout/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/layout/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/layout/favicon-16x16.png">

--- a/feed.json
+++ b/feed.json
@@ -1,0 +1,25 @@
+---
+layout: null
+---
+{
+    "version": "https://jsonfeed.org/version/1",
+    "title": "{{ site.title | xml_escape }}",
+    "description": {{ site.description | jsonify }},
+    "home_page_url": "{{ "/" | absolute_url }}",
+    "feed_url": "{{ "/feed.json" | absolute_url }}",
+    "user_comment": "This feed allows you to read the posts from this site in any feed reader that supports the JSON Feed format.",
+    "items": [{% for post in site.posts %}
+        {
+            "id": "{{ post.url | absolute_url }}",
+            "url": "{{ post.url | absolute_url }}",
+            "title": {{ post.title | jsonify }},
+            "content_html": {{ post.content | jsonify }},
+            "date_published": "{{ post.date | date_to_xmlschema }}",
+            "authors": [{% for author in post.author %}
+                {
+                    "name": "{{ author }}"
+                }{% unless forloop.last %}, {% endunless %}{% endfor %}
+            ]
+        }{% unless forloop.last %},{% endunless %}{% endfor %}
+    ]
+}


### PR DESCRIPTION
[JSON Feed](https://www.jsonfeed.org/) is the new, modern standard for feeds.

This PR ties into #25 (and #744).

Changes:
- Add JSON feed
- Add JSON & XML feeds to site head