### PR TITLE
Add AdGuard privacy policy

### DIFF
--- a/_data/software/browsers-resources/2_adguard.yml
+++ b/_data/software/browsers-resources/2_adguard.yml
@@ -6,6 +6,7 @@ description: |
 
   There is also [AdGuard for iOS](https://adguard.com/en/adguard-ios/overview.html) which is able to perform system wide adblocking.
 website: 'https://adguard.com/en/adguard-safari/overview.html'
+privacy_policy: 'https://adguard.com/en/privacy/safari.html'
 downloads:
   - icon: fab fa-app-store-ios
     url: 'https://apps.apple.com/app/adguard-for-safari/id1440147259'


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Resolves: #724 

Adds privacy policy to the AdGuard for iOS card.

I used the [privacy policy for safari browser](https://adguard.com/en/privacy/safari.html) instead of the [general](https://adguard.com/en/privacy.html) one.