### PR TITLE
Make the navbar work without javascript

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-primary">
+<nav class="navbar navbar-expand-lg navbar-light bg-primary noscript">
   <div class="container">
     <a class="navbar-brand" href="/">
       <picture>

--- a/_sass/noscript.scss
+++ b/_sass/noscript.scss
@@ -1,0 +1,13 @@
+.noscript {
+  .dropdown:hover .dropdown-menu {
+    display: block;
+    right: 0;
+    left: auto;
+  }
+  .navbar-toggler {
+    display: none;
+  }
+  #navbarSupportedContent {
+    display: block;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -100,3 +100,4 @@ h1, h2, h3:not(.h5), h4 {
 }
 
 @import "custom";
+@import "noscript";

--- a/assets/css/dark.scss
+++ b/assets/css/dark.scss
@@ -127,3 +127,4 @@ mark, .mark {
 }
 
 @import "custom";
+@import "noscript";

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,7 @@
+window.onload = function () {
+  var navbar = document.querySelector('nav');
+  navbar.classList.remove('noscript');
+}
 document.querySelectorAll(".onclick-select").forEach(element => {
   element.addEventListener("click", element.select);
 });


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Make the navbar work with javascript disabled. This is achieved by adding a `noscript` class to the navbar which is removed if JS is enabled, and styling the `noscript` class to expand dropdowns on hover.

Resolves: #571 