### PR TITLE
Update iOS Safari card

### DIFF
--- a/_data/software/browsers-mobile/2_safari.yml
+++ b/_data/software/browsers-mobile/2_safari.yml
@@ -32,8 +32,8 @@ description: |
     <li>Toggle Off: <strong>Check for Apple Pay</strong>.</li>
   </ul>
 
-  ##### **Always-on Private Tabs**
-  Open Safari and press the tabs button at the bottom right corner. Open Tab Groups, located in the bottom middle.
+  ##### **Always-on Private Browsing**
+  Open Safari and press the tabs icon in the bottom right corner. Open Tab Groups, located in the bottom middle.
 
   <ul style="list-style-type:none;padding-left:0;">
     <li>Select: <strong>Private</strong>.</li>

--- a/_data/software/browsers-mobile/2_safari.yml
+++ b/_data/software/browsers-mobile/2_safari.yml
@@ -2,17 +2,19 @@ title: Safari
 type: Recommendation
 logo: /assets/img/browsers/safari.svg
 description: |
-  **Safari** is the default browser in iOS. It includes [privacy features](https://support.apple.com/guide/iphone/browse-the-web-privately-iphb01fc3c85/15.0/ios/15.0) such as tracking protection, isolated private tabs, iCloud Private Relay to hide your IP address from trackers, and automatic https upgrade.
+  **Safari** is the default browser in iOS. It includes [privacy features](https://support.apple.com/guide/iphone/browse-the-web-privately-iphb01fc3c85/15.0/ios/15.0) such as Intelligent Tracking Protection, Privacy Report, isolated Private Browsing tabs, iCloud Private Relay, and automatic HTTPS upgrades.
 
   These options can be found in *Privacy and Security* (⚙️ Settings → Safari → Privacy and Security).
 
   ##### **Cross-Site Tracking Prevention**
+  Toggling this setting enables WebKit's [Intelligent Tracking Protection](https://webkit.org/tracking-prevention/#intelligent-tracking-prevention-itp).
+
   <ul style="list-style-type:none;padding-left:0;">
     <li>Toggle On: <strong>Prevent Cross-Site Tracking</strong>.</li>
   </ul>
 
   ##### **Privacy Preserving Ad Measurement**
-  This is Apple's own implementation of private ad tracking. If you don't wish to participate, you can disable this feature.
+  This is WebKit's own [implementation](https://webkit.org/blog/8943/privacy-preserving-ad-click-attribution-for-the-web/) of private preserving ad click attribution. If you do not wish to participate, you can disable this feature.
 
   <ul style="list-style-type:none;padding-left:0;">
     <li>Toggle Off: <strong>Privacy Preserving Ad Measurement</strong>.</li>
@@ -26,14 +28,16 @@ description: |
   </ul>
 
   ##### **Always-on Private Tabs**
-  Open Safari and press the tabs button at the bottom right corner. In the bottom middle press the downward facing arrow.
+  Open Safari and press the tabs button at the bottom right corner. Open Tab Groups, located in the bottom middle.
 
   <ul style="list-style-type:none;padding-left:0;">
     <li>Select: <strong>Private</strong>.</li>
   </ul>
 
-  #### Sync
-  History, tabs, and iCloud tabs are end-to-end encrypted. However, bookmarks are [not](https://support.apple.com/en-us/HT202303). Although they are stored in an encrypted form, it is possible for Apple to decrypt them.
+  #### iCloud Sync
+  The synchronization of some data is [not](https://support.apple.com/en-us/HT202303) end-to-end encrypted. While synchronization of Safari History, Tab Groups, and iCloud Tabs are end-to-end encrypted; bookmarks are only encrypted in transit and stored in an encrypted format. As bookmarks are not end-to-end encrypted, Apple may be able to decrypt and access them.
+
+  If you use iCloud, we also recommend checking to ensure Safari's default download location is set to locally on your device. This option can be found in *General* (⚙️ Settings → Safari → General → Downloads).
 
   #### Extensions
   We generally do not recommend installing [any extensions](https://www.sentinelone.com/blog/inside-safari-extensions-malware-golden-key-user-data/) as they increase your browser's [attack surface](https://en.wikipedia.org/wiki/Attack_surface); however, if you want content blocking, [AdGuard for Safari](/browsers/#additional-resources) might be useful to you.

--- a/_data/software/browsers-mobile/2_safari.yml
+++ b/_data/software/browsers-mobile/2_safari.yml
@@ -13,6 +13,11 @@ description: |
     <li>Toggle On: <strong>Prevent Cross-Site Tracking</strong>.</li>
   </ul>
 
+  ##### **Privacy Report**
+  Privacy Report provides a snapshot of cross-site trackers currently prevented from profiling you on the website you're visiting. It can also display a weekly report to show which trackers have been blocked over time.
+
+  Privacy Report is accessible through the **Aa** icon in the URL bar.
+
   ##### **Privacy Preserving Ad Measurement**
   This is WebKit's own [implementation](https://webkit.org/blog/8943/privacy-preserving-ad-click-attribution-for-the-web/) of private preserving ad click attribution. If you do not wish to participate, you can disable this feature.
 


### PR DESCRIPTION
### Changes
- Refer to Safari's tracking prevention, private tabs, and sync by their official name
- List Privacy Report under Safari's privacy features
- Mention and link to WebKit ITP
- Section on Privacy Report feature
- Update Privacy Preserving Ad Measurement section
  - Change to state that it's a WebKit feature
- Rephrase Always-on Private Browsing instructions
- Update iCloud Sync section
  - Rephrase
  - Reminder to change default download location to on device instead of iCloud Drive