### PR TITLE
Fix cardv2 dark mode images

### DIFF
--- a/_includes/legacy/cardv2.html
+++ b/_includes/legacy/cardv2.html
@@ -28,16 +28,20 @@
   </div>
   <div class="card-body">
     <p class="card-text">
-      <img
-        src="{{include.image}}"
+      <picture>
         {% if include.image-dark %}
-        data-theme-src="{{include.image-dark}}"
-        {% endif %}
-        height="120"
-        width="120"
-        class="panel-pic"
-        alt="{{include.title}} logo"
-      >
+        <source
+          srcset="{{include.image-dark}}"
+          media="(prefers-color-scheme: dark)"
+        >{% endif %}
+        <img
+          src="{{include.image}}"
+          height="120"
+          width="120"
+          class="panel-pic"
+          alt="{{include.title}} logo"
+        >
+      </picture>
       {{ include.description }}
       {% if include.labels %}
       {% assign labels = include.labels | split:"|" %}


### PR DESCRIPTION
Fixes the `image-dark` tag in cardv2

## Example

### Write.as card
#### Before
![before1-opti](https://user-images.githubusercontent.com/100533118/160007662-4e9ede81-96d9-4e13-a896-3904b4f4071f.png)

#### After
![after1-opti](https://user-images.githubusercontent.com/100533118/160007678-00fc04d2-19d0-410d-a4fe-e1038e64f947.png)
