### PR TITLE
Update WireGuard information on VPN provider page

### DIFF
--- a/_includes/legacy/sections/vpn.html
+++ b/_includes/legacy/sections/vpn.html
@@ -1,7 +1,7 @@
 <h2 id="vpn" class="anchor"><a href="#vpn"><i class="fas fa-link anchor-icon"></i></a> Recommended VPN Services</h2>
 
 <div class="alert alert-success" role="alert">
-  <strong>Our recommended providers are outside the US, use encryption, accept Bitcoin, support OpenVPN, and have a no logging policy. <a href="/providers/vpn/#criteria">Read our full list of criteria for more information</a>.</strong>
+  <strong>Our recommended providers are outside the US, use encryption, accept Bitcoin, support WireGuard & OpenVPN, and have a no logging policy.<br><a href="/providers/vpn/#criteria">Read our full list of criteria for more information</a>.</strong>
 </div>
 
 <div class="container-fluid">
@@ -38,9 +38,10 @@
     <h5>{% include badge.html color="success" text="Open Source Clients" %}</h5>
     <p>Mullvad provides the source code for their desktop and mobile clients in their <a href="https://github.com/mullvad/mullvadvpn-app">GitHub organization</a>.</p>
     <h5>{% include badge.html color="success" text="Accepts Bitcoin" %}</h5>
-    <p>Mullvad in addition to accepting credit/debit cards and PayPal, accepts <strong>Bitcoin</strong>, <strong>Bitcoin Cash</strong>, and <strong>cash/local currency</strong> as anonymous forms of payment. They also accept Swish and bank wire transfers.</p>
+    <p>Mullvad, in addition to accepting credit/debit cards and PayPal, accepts <strong>Bitcoin</strong>, <strong>Bitcoin Cash</strong>, and <strong>cash/local currency</strong> as anonymous forms of payment. They also accept Swish and bank wire transfers.</p>
     <h5>{% include badge.html color="success" text="WireGuard Support" %}</h5>
-    <p>In addition to standard OpenVPN connections, Mullvad supports WireGuard. WireGuard is an experimental protocol with theoretically better security and higher reliability, although it is not currently recommended for production use.</p>
+    <p>Mullvad supports the WireGuard&reg; protocol. <a href="https://www.wireguard.com">WireGuard</a> is a newer protocol that utilizes state-of-the-art <a href="https://www.wireguard.com/protocol/">cryptography</a>. Additionally, WireGuard aims to be simpler and more performant.</p>
+    <p>Mullvad <a href="https://mullvad.net/en/help/why-wireguard/">recommends</a> the use of WireGuard with their service. It is the default or only protocol on Mullvad's Android, iOS, macOS, and Linux apps, whereas Windows users have to <a href="https://mullvad.net/en/help/how-turn-wireguard-mullvad-app/">manually enable</a> WireGuard. Mullvad also offers a WireGuard configuration generator for use with the official WireGuard <a href="https://www.wireguard.com/install/">apps</a>.</p>
     <h5>{% include badge.html color="success" text="IPv6 Support" %}</h5>
     <p>Mullvad supports the future of networking <a href="https://en.wikipedia.org/wiki/IPv6">IPv6</a>. Their network allows users to <a href="https://mullvad.net/en/blog/2014/9/15/ipv6-support/">access services hosted on IPv6</a> as opposed to other providers who block IPv6 connections.</p>
     <h5>{% include badge.html color="success" text="Remote Port Forwarding" %}</h5>
@@ -72,6 +73,9 @@
     <p>ProtonVPN provides the source code for their desktop and mobile clients in their <a href="https://github.com/ProtonVPN">GitHub organization</a>.</p>
     <h5>{% include badge.html color="success" text="Accepts Bitcoin" %}</h5>
     <p>ProtonVPN does technically accept Bitcoin payments; however, you either need to have an existing account, or contact their support team in advance to register with Bitcoin.</p>
+    <h5>{% include badge.html color="success" text="WireGuard Support" %}</h5>
+    <p>ProtonVPN mostly supports the WireGuard&reg; protocol. <a href="https://www.wireguard.com">WireGuard</a> is a newer protocol that utilizes state-of-the-art <a href="https://www.wireguard.com/protocol/">cryptography</a>. Additionally, WireGuard aims to be simpler and more performant.</p>
+    <p>ProtonVPN <a href="https://protonvpn.com/blog/wireguard/">recommends</a> the use of WireGuard with their service. On ProtonVPN's Windows, macOS, iOS, Android, ChromeOS, and Android TV apps, WireGuard is the default protocol; however, <a href="https://protonvpn.com/support/how-to-change-vpn-protocols/">support</a> for the protocol is not present in their Linux app.</p>
     <h5>{% include badge.html color="success" text="Mobile Clients" %}</h5>
     <p>In addition to providing standard OpenVPN configuration files, ProtonVPN has mobile clients for <a href="https://apps.apple.com/us/app/protonvpn-fast-secure-vpn/id1437005085">App Store</a> and <a href="https://play.google.com/store/apps/details?id=ch.protonvpn.android&hl=en_US">Google Play</a> allowing for easy connections to their servers. The mobile client on Android is also available in <a href="https://f-droid.org/en/packages/ch.protonvpn.android">F-Droid</a>, which ensures that it is compiled with <a href="https://www.f-droid.org/en/2019/05/05/trust-privacy-and-free-software.html">reproducible builds</a>.</p>
     <h5>{% include badge.html color="warning" text="No Port Forwarding" %}</h5>
@@ -101,7 +105,8 @@
     <h5>{% include badge.html color="success" text="Accepts Bitcoin" %}</h5>
     <p>In addition to accepting credit/debit cards and PayPal, IVPN accepts <strong>Bitcoin</strong>,  <strong>Monero</strong> and <strong>cash/local currency</strong> (on annual plans) as anonymous forms of payment.</p>
     <h5>{% include badge.html color="success" text="WireGuard Support" %}</h5>
-    <p>In addition to standard OpenVPN connections, IVPN supports WireGuard. WireGuard is an experimental protocol with theoretically better security and higher reliability, although it is not currently recommended for production use.</p>
+    <p>IVPN supports the WireGuard&reg; protocol. <a href="https://www.wireguard.com">WireGuard</a> is a newer protocol that utilizes state-of-the-art <a href="https://www.wireguard.com/protocol/">cryptography</a>. Additionally, WireGuard aims to be simpler and more performant.</p>
+    <p>IVPN <a href="https://www.ivpn.net/wireguard/">recommends</a> the use of WireGuard with their service and, as such, the protocol is the default on all of IVPN's apps. IVPN also offers a WireGuard configuration generator for use with the official WireGuard <a href="https://www.wireguard.com/install/">apps</a>.</p>
     <h5>{% include badge.html color="success" text="Remote Port Forwarding" %}</h5>
     <p>Remote <a href="https://en.wikipedia.org/wiki/Port_forwarding">port forwarding</a> is possible with a Pro plan. Port forwarding <a href="https://www.ivpn.net/knowledgebase/81/How-do-I-activate-port-forwarding.html">can be activated</a> via the client area. Port forwarding is only available on IVPN when using WireGuard or OpenVPN protocols and is <a href="https://www.ivpn.net/knowledgebase/116/Port-forwarding-is-not-working-why.html">disabled on US servers</a>.</p>
     <h5>{% include badge.html color="success" text="Mobile Clients" %}</h5>
@@ -112,6 +117,8 @@
   </div>
 </div>
 
+<br>
+<br>
 <div class="alert alert-warning" role="alert">
   <strong>Note: Using a VPN provider will not make you anonymous, but it will give you better privacy in certain situations. A VPN is not a tool for illegal activities. Don't rely on a "no log" policy.</strong>
 </div>

--- a/legacy_pages/providers/vpn.html
+++ b/legacy_pages/providers/vpn.html
@@ -52,7 +52,7 @@ description: "Find a no-logging VPN operator who isn't out to sell or read your 
     <div class="col-md-6">
       <p><strong>Minimum to Qualify:</strong></p>
       <ul>
-        <li>Support for strong protocols such as OpenVPN.</li>
+        <li>Support for strong protocols such as WireGuard & OpenVPN.</li>
         <li>Killswitch built in to clients.</li>
         <li>Multihop support. Multihopping is important to keep data private in case of a single node compromise.</li>
         <li>If VPN clients are provided, they should be <a href="https://en.wikipedia.org/wiki/Open_source">open source</a>, like the VPN software they generally have built into them. We believe that <a href="https://en.wikipedia.org/wiki/Source_code">source code</a> availability provides greater transparency to the user about what their device is actually doing. We like to see these applications <a href="https://www.f-droid.org/en/2019/05/05/trust-privacy-and-free-software.html">available in F-Droid</a>.</li>
@@ -61,7 +61,7 @@ description: "Find a no-logging VPN operator who isn't out to sell or read your 
     <div class="col-md-6">
       <p><strong>Best Case:</strong></p>
       <ul>
-        <li>OpenVPN and WireGuard support.</li>
+        <li>WireGuard and OpenVPN support.</li>
         <li>Killswitch with highly configurable options (enable/disable on certain networks, on boot, etc.)</li>
         <li>Easy-to-use VPN clients</li>
         <li>Supports <a href="https://en.wikipedia.org/wiki/IPv6">IPv6</a>. We expect that servers will allow incoming connections via IPv6 and allow users to access services hosted on IPv6 addresses.</li>
@@ -211,6 +211,10 @@ description: "Find a no-logging VPN operator who isn't out to sell or read your 
           <li><a href="https://www.ivpn.net/privacy-guides/">IVPN Privacy Guides</a></li>
         </ol>
       <p>
+    <div class="col">
+      <p><strong>Legal</strong>:</p>
+      <p>"WireGuard" and the "WireGuard" logo are registered trademarks of Jason A. Donenfeld.</p>
+    </div>
     </div>
   </div>
 


### PR DESCRIPTION
Someone on Matrix mentioned that currently the page states WireGuard is "experimental" and "not currently recommended for production use." I think these statements aren't entirely accurate anymore; WireGuard has proven itself as is demonstrated by almost all reputable VPN companies ([Mullvad](https://mullvad.net/en/help/why-wireguard/), [IVPN](https://www.ivpn.net/wireguard/), [ProtonVPN](https://protonvpn.com/blog/wireguard/), etc) adopting it as a default and by it being incorporated into the Linux kernel.

### Changes
- Update WireGuard description for all providers
- Update minimum to qualify criteria to include WireGuard
- Update criteria alert to include WireGuard and add line break before long link
- Include WireGuard support for ProtonVPN
- State for which apps, per provider, WireGuard is the default
- Mention which providers feature a WireGuard config generator for use with the official WireGuard apps
- Include a legal note as required by [WireGuard's trademark policy](https://www.wireguard.com/trademark-policy/)
- Add more spacing above VPN warning so it doesn't appear as if it's specifically applying to IVPN