### PR TITLE
Correct spelling of Wi-Fi

### DIFF
--- a/collections/_evergreen/linux-desktop.md
+++ b/collections/_evergreen/linux-desktop.md
@@ -128,15 +128,15 @@ We **highly recommend** that you install the microcode updates, as your CPU is a
 
 ## Privacy tweaks
 ### MAC address randomization
-Many desktop Linux distributions (Fedora, openSUSE etc) will come with [NetworkManager](https://en.wikipedia.org/wiki/NetworkManager), to configure Ethernet and WiFi settings.
+Many desktop Linux distributions (Fedora, openSUSE etc) will come with [NetworkManager](https://en.wikipedia.org/wiki/NetworkManager), to configure Ethernet and Wi-Fi settings.
 
-It is possible to [randomize](https://fedoramagazine.org/randomize-mac-address-nm/) the [MAC address](https://en.wikipedia.org/wiki/MAC_address) when using NetworkManager. This provides a bit more privacy on WiFi networks as it makes it harder to track specific devices on the network you're connected to. It does [**not**](https://papers.mathyvanhoef.com/wisec2016.pdf) make you anonymous.
+It is possible to [randomize](https://fedoramagazine.org/randomize-mac-address-nm/) the [MAC address](https://en.wikipedia.org/wiki/MAC_address) when using NetworkManager. This provides a bit more privacy on Wi-Fi networks as it makes it harder to track specific devices on the network you're connected to. It does [**not**](https://papers.mathyvanhoef.com/wisec2016.pdf) make you anonymous.
 
 We recommend changing the setting to **random** instead of **stable**, as suggested in the [article](https://fedoramagazine.org/randomize-mac-address-nm/).
 
 If you are using [systemd-networkd](https://en.wikipedia.org/wiki/Systemd#Ancillary_components), you will need to set [`MACAddressPolicy=random`](https://www.freedesktop.org/software/systemd/man/systemd.link.html#MACAddressPolicy=) which will enable [RFC 7844 (Anonymity Profiles for DHCP Clients)](https://www.freedesktop.org/software/systemd/man/systemd.network.html#Anonymize=).
 
-There isn't much point in randomizing the MAC address for Ethernet connections as a system administrator can find you by looking at the port you are using on the [network switch](https://en.wikipedia.org/wiki/Network_switch). Randomizing WiFi MAC addresses depends on support from the WiFi's firmware.
+There isn't much point in randomizing the MAC address for Ethernet connections as a system administrator can find you by looking at the port you are using on the [network switch](https://en.wikipedia.org/wiki/Network_switch). Randomizing Wi-Fi MAC addresses depends on support from the Wi-Fi's firmware.
 
 ### Other identifiers
 There are other system [identifiers](https://madaidans-insecurities.github.io/guides/linux-hardening.html#identifiers) which you may wish to be careful about. You should give this some thought to see if it applies to your [threat model](/threat-modeling):

--- a/collections/_evergreen/router.md
+++ b/collections/_evergreen/router.md
@@ -3,7 +3,7 @@ layout: evergreen
 title: Router
 mathjax: false
 description: |
-  Below are a few alternative operating systems, that can be used on routers, wifi access points etc.
+  Below are a few alternative operating systems, that can be used on routers, Wi-Fi access points etc.
 ---
 
 {% for item_hash in site.data.operating-systems.router %}


### PR DESCRIPTION
## Description

Correct spelling of Wi-Fi (according to Wikipedia) in Linux Desktop &
Router pages