### PR TITLE
Include 'Yes' branch in DNS flowchart

### DIFF
--- a/docs/dns.md
+++ b/docs/dns.md
@@ -105,6 +105,7 @@ graph TB
     anonymous --> | No | censorship{Avoiding censorship?}
     censorship --> | Yes | vpnOrTor(Use VPN or Tor)
     censorship --> | No | privacy{Want privacy from ISP?}
+    privacy --> | Yes | vpnOrTor(Use VPN or Tor)
     privacy --> | No | obnoxious{ISP makes obnoxious redirects?}
     obnoxious --> | Yes | encryptedDNS(Use encrypted DNS with 3rd party)
     obnoxious --> | No | ispDNS{Does ISP support encrypted DNS?}


### PR DESCRIPTION
Currently, the flowchart in Providers -> DNS Servers is missing a 'Yes' branch from the 'Want Privacy from ISP?' decision box. This corrects it to have a Yes branch going to 'Use a VPN or Tor', as shown in #767