### PR TITLE
Remove wrong ios app store link for FairEmail

### DIFF
--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -98,7 +98,6 @@ Discover free, open-source, and secure email clients, along with some email alte
     **Downloads**
     - [:fontawesome-brands-google-play: Google Play](https://play.google.com/store/apps/details?id=eu.faircode.email)
     - [:pg-f-droid: F-Droid](https://f-droid.org/packages/com.fsck.k9)
-    - [:fontawesome-brands-app-store-ios: App Store](https://f-droid.org/en/packages/eu.faircode.email)
     - [:fontawesome-brands-github: Source](https://github.com/M66B/FairEmail)
 
 ### Canary Mail


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

## Description

Resolves: Removes wrong ios app store link for FairEmail# <!-- Did you solve an open GitHub issue? Put the number here so we mark it complete! -->

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
