### PR TITLE
Add warning about SEIC curve

### DIFF
--- a/docs/file-sharing.md
+++ b/docs/file-sharing.md
@@ -46,6 +46,9 @@ Discover how to privately share your files between your devices, with your frien
 
     **Croc** is a way to easily and securely send arbitrary-sized files from one computer to another. Similar to Magic Wormhole but without dependencies, resulting in a smaller application.
 
+    !!! Warning
+        The default encryption curve SIEC is fairly unknown and has not been tested thoroughly. We recommend using the `--curve` [option](https://github.com/schollz/croc/blob/master/README.md#change-encryption-curve) to switch to a more widely known curve such as the p521 curve.
+
     [Visit schollz.com](https://schollz.com/blog/croc6){ .md-button .md-button--primary }
 
     **Downloads**


### PR DESCRIPTION
Closes: https://github.com/privacytools/privacytools.io/issues/2385

I was browsing through our [old repo](https://github.com/privacytools/privacytools.io/issues/991) and noticed this  PR https://github.com/privacytools/privacytools.io/pull/2386.

Seems it was added [a long time ago](https://github.com/privacytools/privacytools.io/commit/23804e3844c19644f14586b0cc56d8c83eec2519) without much discussion.

We should have a warning for this, or consider removing it. The software is still actively developed.

https://www.reddit.com/r/cryptography/comments/mult11/siec_elliptic_curve_vs_other_better_known_ones/