### PR TITLE
Imagepipe F-Droid link correction

### DIFF
--- a/docs/metadata-removal-tools.md
+++ b/docs/metadata-removal-tools.md
@@ -73,7 +73,7 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
     [Visit codeberg.org](https://codeberg.org/Starfish/Imagepipe){ .md-button .md-button--primary }
 
     **Downloads**
-    - [:pg-f-droid: F-Droid](https://f-droid.org/en/packages/com.jarsilio.android.scrambledeggsif)
+    - [:pg-f-droid: F-Droid](https://f-droid.org/en/packages/de.kaffeemitkoffein.imagepipe/)
     - [:fontawesome-brands-git: Source](https://codeberg.org/Starfish/Imagepipe)
 
 ### Metapho


### PR DESCRIPTION
<!-- Submitting a PR? Awesome!! -->

This PR corrects the F-Droid link for the metadata removal tool Imagepipe. 

Currently the link forwards to Scrambled Exif F-Droid page.

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
