### PR TITLE
Add changelog, deploy on tagged releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,12 @@
 # Additional Co-Owners are added to the TOP of this file.
 
 # High-traffic pages
-/index.html @JonahAragon @dngray
-/blog.html @JonahAragon
+/docs/index.md @JonahAragon @dngray
+/theme/overrides/ @JonahAragon
 
-# Org/legal
-/notices.md @JonahAragon
-/privacy-policy.md @JonahAragon
+# Org
+/docs/about/ @JonahAragon
 LICENSE @JonahAragon
-
-# Website dev
-/_sass/ @JonahAragon
-/_layouts/ @JonahAragon
-Gemfile @JonahAragon
-Gemfile.lock @JonahAragon
-_config.yml @JonahAragon
 
 # Ops
 /.github/ @JonahAragon

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy Website
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 env:
   PYTHON_VERSION: 3.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Privacy Guides Changelog
+
+<!-- Add the date and any new changes to the TOP of this file, below this line. -->
+
+## 2022-04-11
+
+- Added changelog
+- Switched to release-based deployments (#980)
+- Removed blog from repo, moved to [blog.privacyguides.org](https://blog.privacyguides.org)
+- Add RSS page ([#895](https://github.com/privacyguides/privacyguides.org/pull/895/))
+- MFA/YubiKey clarifications ([#972](https://github.com/privacyguides/privacyguides.org/pull/972))
+
+---
+
+*Massive thanks to [u/SnowCatFalcon](https://www.reddit.com/user/SnowCatFalcon/) for publishing [changelogs on our Subreddit](https://www.reddit.com/r/PrivacyGuides/comments/tu2dvw/privacy_guides_changelogs_march_2022/) before we added this file.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ## 2022-04-11
 
 - Added changelog
-- Switched to release-based deployments (#980)
-- Removed blog from repo, moved to [blog.privacyguides.org](https://blog.privacyguides.org)
+- Switched to release-based deployments ([#987](https://github.com/privacyguides/privacyguides.org/pull/987))
+- Removed blog from repo, moved to [blog.privacyguides.org](https://blog.privacyguides.org) ([#985](https://github.com/privacyguides/privacyguides.org/pull/985))
 - Add RSS page ([#895](https://github.com/privacyguides/privacyguides.org/pull/895/))
 - MFA/YubiKey clarifications ([#972](https://github.com/privacyguides/privacyguides.org/pull/972))
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@
   </a></p>
 </div>
 
+## About
+
+**Privacy Guides** is a socially motivated website that provides information for protecting your data security and privacy. We are a non-profit collective operated entirely by volunteer team members and contributors.
+
+Our current list of team members can be found [here](https://github.com/orgs/privacyguides/people). Additionally, [many people](https://github.com/privacyguides/privacyguides.org/graphs/contributors) have made contributions to the project, and you can too!
+
+## Contributing
+
+- 💬 [Start a discussion or suggest an idea](https://github.com/privacyguides/privacyguides.org/discussions)
+- 💖 [Sponsor the project](https://github.com/sponsors/privacyguides)
+- 📝 Edit the site, everything's accessible in this repo
+  - Browse our [open issues](https://github.com/privacyguides/privacyguides.org/issues) to see what needs to be updated
+  - When making more significant (than simple typo fixes, etc.) changes, update the [changelog](/CHANGELOG.md)
+  - View some contribution tips on our [contributor's wiki](https://github.com/privacyguides/privacyguides.org/wiki)
+
 ## Developing
 
 1. Clone this repository: `git clone https://github.com/privacyguides/privacyguides.org`
@@ -44,3 +59,17 @@
 3. Install [mkdocs-material](https://squidfunk.github.io/mkdocs-material/getting-started/): `pip install mkdocs-material`
 4. Serve the site locally: `mkdocs serve`
     - The site will be available at `http://localhost:8000/`.
+  
+Your local site will appear slightly different, because the production version of the website uses a private/custom build of mkdocs-material with additional features.
+
+Team members with access to [mkdocs-material-insiders](https://github.com/privacyguides/mkdocs-material-insiders) should instead:
+
+1. Clone this repository and submodules: `git clone --recurse-submodules https://github.com/privacyguides/privacyguides.org`
+2. Install [Python 3.6+](https://www.python.org/downloads/)
+3. Install **pipenv**: `pip install pipenv`
+4. Start a pipenv shell: `pipenv shell`
+5. Install dependencies: `pipenv install --dev`
+6. Serve the site locally: `mkdocs serve --config-file mkdocs.production.yml`
+    - The site will be available at `http://localhost:8000`
+    - You can build the site locally with `mkdocs build --config-file mkdocs.production.yml`
+    - This version of the site should be identical to the live, production version


### PR DESCRIPTION
From discussion #980 

This changes our deployment so that changes are **not** made on every push to `main`. The website is only updated when a release is published on GitHub. Hopefully it's better for people keeping track of changes to the website, it will also show a version number on the website. When we get translations going, having an easily visible version number/release schedule will make it easy to compare translations the main website.

This also adds a CHANGELOG.md file which ideally should be updated in every PR. We can then easily copy new info from that file to the release description when we deploy a new release.