### PR TITLE
Add link to Discussions in nav bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Add the date and any new changes to the TOP of this file, below this line. -->
 
+## 2022-04-12
+
+- Enabled organization discussions ([#986](https://github.com/orgs/privacyguides/discussions/986))
+- Added a navbar link to the new [organization discussions](https://github.com/orgs/privacyguides/discussions) ([#994](https://github.com/privacyguides/privacyguides.org/pull/994))
+
 ## 2022-04-11
 
 - Added changelog

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
     - 'Notices': 'about/notices.md'
     - 'Privacy Policy': 'about/privacy-policy.md'
   - 'Blog': 'https://blog.privacyguides.org/'
+  - 'Discussions': 'https://github.com/orgs/privacyguides/discussions'
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,8 +65,8 @@ nav:
     - 'Privacy Guides': 'about.md'
     - 'Notices': 'about/notices.md'
     - 'Privacy Policy': 'about/privacy-policy.md'
-  - 'Blog': 'https://blog.privacyguides.org/'
   - 'Discussions': 'https://github.com/orgs/privacyguides/discussions'
+  - 'Blog': 'https://blog.privacyguides.org/'
 
 theme:
   name: material


### PR DESCRIPTION
Adds a navbar link to the new [organization discussions](https://github.com/orgs/privacyguides/discussions).

By having a prominent link to the discussions I'm thinking it could get more people involved.