### PR TITLE
Use abbreviations across site

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -11,4 +11,8 @@ files:
   translation: "/theme/overrides/%file_name%.%locale_with_underscore%.html"
   translation_replace:
     "en.": ""
+- source: "/includes/*.en.md"
+  translation: "/includes/%file_name%.%locale_with_underscore%.md"
+  translation_replace:
+    "en.": ""
   update_option: update_as_unapproved

--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -15,7 +15,7 @@ Generally speaking we recommend installing one of these custom Android operating
 
 !!! note
 
-    End-of-life devices (such as GrapheneOS or CalyxOS's "extended support" devices) do not have full security patches (firmware updates) due to the original equipment manufacturer (OEM) discontinuing support. These devices cannot be considered completely secure regardless of installed software.
+    End-of-life devices (such as GrapheneOS or CalyxOS's "extended support" devices) do not have full security patches (firmware updates) due to the OEM discontinuing support. These devices cannot be considered completely secure regardless of installed software.
 
 ### GrapheneOS
 
@@ -26,7 +26,7 @@ Generally speaking we recommend installing one of these custom Android operating
 
     **GrapheneOS** is the best choice when it comes to privacy and security.
 
-    GrapheneOS provides additional [security hardening](https://en.wikipedia.org/wiki/Hardening_(computing)) and privacy improvements. It has a [hardened memory allocator](https://github.com/GrapheneOS/hardened_malloc), network and sensor permissions, and various other [security features](https://grapheneos.org/features). GrapheneOS also comes with full firmware updates and signed builds, so [verified boot](https://source.android.com/security/verifiedboot) is fully supported.
+    GrapheneOS provides additional [security hardening](https://en.wikipedia.org/wiki/Hardening_(computing)) and privacy improvements. It has a [hardened memory allocator](https://github.com/GrapheneOS/hardened_malloc), network and sensor permissions, and various other [security features](https://grapheneos.org/features). GrapheneOS also comes with full firmware updates and signed builds, so verified boot is fully supported.
 
     [Visit grapheneos.org](https://grapheneos.org/){ .md-button .md-button--primary } [Privacy Policy](https://grapheneos.org/faq#privacy-policy){ .md-button }
 
@@ -40,7 +40,7 @@ Currently, only [Pixel phones](https://grapheneos.org/faq#device-support) meet i
 
     ![CalyxOS logo](assets/img/android/calyxos.svg){ align=right }
 
-    **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so [verified boot](https://source.android.com/security/verifiedboot) is fully supported.
+    **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so verified boot is fully supported.
 
     [Visit calyxos.org](https://calyxos.org/){ .md-button .md-button--primary } [Privacy Policy](https://calyxinstitute.org/legal/privacy-policy){ .md-button }
 
@@ -69,7 +69,7 @@ DivestOS 16.0, 17.1, and 18.1 implements GrapheneOS's [`INTERNET`](https://devel
 
     DivestOS firmware update [status](https://gitlab.com/divested-mobile/firmware-empty/-/blob/master/STATUS) varies across the devices it supports. For Pixel phones, we still recommend using GrapheneOS or CalyxOS. For other supported devices, DivestOS is a good alternative.
 
-    Not all of the supported devices have [verified boot](https://source.android.com/security/verifiedboot), and some perform it better than others.
+    Not all of the supported devices have verified boot, and some perform it better than others.
 
 ## Android Devices
 
@@ -112,7 +112,7 @@ A few more tips for purchasing a Google Pixel:
 
 !!! important
 
-    Google Pixel phones are the only devices which are fully supported by all of our recommended Android distributions. Additionally, Pixel devices have stronger hardware security than any other Android device currently on the market, due to Google's custom Titan security chips acting as the Secure Element for secrets storage and rate limiting. Secure Elements are more limited and have a smaller attack surface than the Trusted Execution Environment (TEE), which is also used to run "trusted" programs. Most other phones do not have a Secure Element and have to using the TEE for both secrets storage, rate limiting, and trusted computing."
+    Google Pixel phones are the only devices which are fully supported by all of our recommended Android distributions. Additionally, Pixel devices have stronger hardware security than any other Android device currently on the market, due to Google's custom Titan security chips acting as the Secure Element for secrets storage and rate limiting. Secure Elements are more limited and have a smaller attack surface than the Trusted Execution Environment used by most other phones, which is also used to run "trusted" programs. Phones without a Secure Element have to use the TEE for secrets storage, rate limiting, *and* trusted computing."
 
 If you are unable to purchase a Pixel device, any device which is supported by CalyxOS should be reasonably secure and private enough for most users after installing CalyxOS.
 
@@ -324,3 +324,5 @@ To mitigate these problems, we recommend [Droid-ify](https://github.com/Iamlooke
     **Downloads:**
     - [:fontawesome-brands-android: APK Download](https://android.izzysoft.de/repo/apk/com.looker.droidify)
     - [:fontawesome-brands-github: GitHub](https://github.com/Iamlooker/Droid-ify)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/android/overview.en.md
+++ b/docs/android/overview.en.md
@@ -4,13 +4,13 @@ icon: material/cellphone-check
 ---
 Android is a secure operating system that has strong [app sandboxing](https://source.android.com/security/app-sandbox), [Verified Boot](https://source.android.com/security/verifiedboot), and a robust [permission](https://developer.android.com/guide/topics/permissions/overview) control system.
 
-The main privacy concern with most Android devices is that they usually include [Google Play Services](https://developers.google.com/android/guides/overview). This component is proprietary, [closed source](https://en.wikipedia.org/wiki/Proprietary_software), has a privileged role on your phone, and may collect private user information. It is neither a part of the [Android Open Source Project](https://source.android.com/) (AOSP) nor is it included with the below derivatives.
+The main privacy concern with most Android devices is that they usually include [Google Play Services](https://developers.google.com/android/guides/overview). This component is proprietary (closed source), has a privileged role on your phone, and may collect private user information. It is neither a part of the [AOSP](https://source.android.com/) nor is it included with the below derivatives.
 
 ## Avoid Root
 
-[Rooting](https://en.wikipedia.org/wiki/Rooting_(Android)) Android phones can decrease security significantly as it weakens the complete [Android security model](https://en.wikipedia.org/wiki/Android_(operating_system)#Security_and_privacy). This can decrease privacy should there be an exploit that is assisted by the decreased security. Common rooting methods involve directly tampering with the boot partition, making it impossible to perform successful [Verified Boot](https://source.android.com/security/verifiedboot). Apps that require root will also modify the system partition meaning that Verified Boot would have to remain disabled. Having root exposed directly in the user interface also increases the [attack surface](https://en.wikipedia.org/wiki/Attack_surface) of your device and may assist in [privilege escalation](https://en.wikipedia.org/wiki/Privilege_escalation) vulnerabilities and [SELinux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) policy bypasses.
+[Rooting](https://en.wikipedia.org/wiki/Rooting_(Android)) Android phones can decrease security significantly as it weakens the complete [Android security model](https://en.wikipedia.org/wiki/Android_(operating_system)#Security_and_privacy). This can decrease privacy should there be an exploit that is assisted by the decreased security. Common rooting methods involve directly tampering with the boot partition, making it impossible to perform successful Verified Boot. Apps that require root will also modify the system partition meaning that Verified Boot would have to remain disabled. Having root exposed directly in the user interface also increases the [attack surface](https://en.wikipedia.org/wiki/Attack_surface) of your device and may assist in [privilege escalation](https://en.wikipedia.org/wiki/Privilege_escalation) vulnerabilities and [SELinux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) policy bypasses.
 
-Adblockers (AdAway) which modify the [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) and firewalls (AFWall+) which require root access persistently are dangerous and should not be used. They are also not the correct way to solve their intended purposes. For Adblocking we suggest encrypted [DNS](../dns.md) or [VPN](../vpn.md) server blocking solutions instead. RethinkDNS, TrackerControl and AdAway in non-root mode will take up the VPN slot (by using a local loopback VPN) preventing you from using privacy enhancing services such as Orbot or a real VPN server.
+Adblockers which modify the [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) (AdAway) and firewalls (AFWall+) which require root access persistently are dangerous and should not be used. They are also not the correct way to solve their intended purposes. For Adblocking we suggest encrypted [DNS](../dns.md) or [VPN](../vpn.md) server blocking solutions instead. RethinkDNS, TrackerControl and AdAway in non-root mode will take up the VPN slot (by using a local loopback VPN) preventing you from using privacy enhancing services such as Orbot or a real VPN server.
 
 AFWall+ works based on the [packet filtering](https://en.wikipedia.org/wiki/Firewall_(computing)#Packet_filter) approach and may be bypassable in some situations.
 
@@ -18,7 +18,7 @@ We do not believe that the security sacrifices made by rooting a phone are worth
 
 ## Firmware Updates
 
-Firmware updates are critical for maintaining security and without them your device cannot be secure. Original equipment manufacturers (OEMs)—in other words, phone manufacturers—have support agreements with their partners to provide the closed source components for a limited support period. These are detailed in the monthly [Android Security Bulletins](https://source.android.com/security/bulletin).
+Firmware updates are critical for maintaining security and without them your device cannot be secure. OEMs have support agreements with their partners to provide the closed source components for a limited support period. These are detailed in the monthly [Android Security Bulletins](https://source.android.com/security/bulletin).
 
 As the components of the phone such as the processor and radio technologies rely on closed source components, the updates must be provided by the respective manufacturers. Therefore it is important that you purchase a device within an active support cycle. [Qualcomm](https://www.qualcomm.com/news/releases/2020/12/16/qualcomm-and-google-announce-collaboration-extend-android-os-support-and) and [Samsung](https://news.samsung.com/us/samsung-galaxy-security-extending-updates-knox/) support their devices for 4 years while cheaper products often have shorter support. With the introduction of the [Pixel 6](https://support.google.com/pixelphone/answer/4457705), Google now makes their own system on chip (SoC) and they will provide 5 years of support.
 
@@ -40,7 +40,7 @@ If you have a Google account we suggest enrolling in the [Advanced Protection Pr
 
 The Advanced Protection Program provides enhanced threat monitoring and enables:
 
-- Stricter two factor authentication; e.g. that [FIDO](/security/multi-factor-authentication/#fido-fast-identity-online) **must** be used and disallows the use of [SMS OTPs](/security/multi-factor-authentication/#sms-or-email-mfa), [TOTP](/security/multi-factor-authentication.md#time-based-one-time-password-totp), and [OAuth](https://en.wikipedia.org/wiki/OAuth)
+- Stricter two factor authentication; e.g. that [FIDO](/security/multi-factor-authentication.md#fido-fast-identity-online) **must** be used and disallows the use of SMS OTPs, TOTP, and [OAuth](https://en.wikipedia.org/wiki/OAuth)
 - Only Google and verified third party apps can access account data
 - Scanning of incoming emails on Gmail accounts for [phishing](https://en.wikipedia.org/wiki/Phishing#Email_phishing) attempts
 - Stricter [safe browser scanning](https://www.google.com/chrome/privacy/whitepaper.html#malware) with Google Chrome
@@ -70,3 +70,5 @@ On Android distributions with privileged Google Play Services (such as stock OSe
 - ⚙️ Settings → Privacy → Ads
 
 Depending on your system, you will either be given the option to delete your advertising ID or to "Opt out of interest-based ads". You should delete the advertising ID if you are given the option to, and if you are not, we recommend that you opt out of interested-based ads and then reset your advertising ID.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/android/security.en.md
+++ b/docs/android/security.en.md
@@ -21,11 +21,11 @@ This method is generally less secure than a secondary user profile; however, it 
 
 [Verified Boot](https://source.android.com/security/verifiedboot) is an important part of the Android security model. It provides protection against [evil maid](https://en.wikipedia.org/wiki/Evil_maid_attack) attacks, malware persistence, and ensures security updates cannot be downgraded with [rollback protection](https://source.android.com/security/verifiedboot/verified-boot#rollback-protection).
 
-Android 10 and above has moved away from full-disk encryption (FDE) to more flexible [file-based encryption](https://source.android.com/security/encryption/file-based).
+Android 10 and above has moved away from full-disk encryption to more flexible [file-based encryption](https://source.android.com/security/encryption/file-based).
 
 Each user's data is encrypted using their own unique encryption key, and the operating system files are left unencrypted. Verified Boot ensures the integrity of the operating system files preventing an adversary with physical access from tampering or installing malware on the device. In the unlikely case that malware is able to exploit other parts of the system and gain higher privileged access, Verified Boot will prevent and revert changes to the system partition upon reboot of the device.
 
-Unfortunately, original equipment manufacturers (OEMs) are only obliged to support Verified Boot on their stock Android distribution. Only a few OEMs such as Google support custom Android Verified Boot (AVB) key enrollment on their devices. Some AOSP derivatives such as LineageOS or /e/ OS do not support Verified Boot even on hardware with Verified Boot support for third party operating systems. We recommend that you check for support **before** purchasing a new device. AOSP derivatives which do not support Verified Boot are **not** recommended.
+Unfortunately, OEMs are only obliged to support Verified Boot on their stock Android distribution. Only a few OEMs such as Google support custom AVB key enrollment on their devices. Some AOSP derivatives such as LineageOS or /e/ OS do not support Verified Boot even on hardware with Verified Boot support for third party operating systems. We recommend that you check for support **before** purchasing a new device. AOSP derivatives which do not support Verified Boot are **not** recommended.
 
 ## VPN Killswitch
 
@@ -33,4 +33,6 @@ Android 7 and above supports a VPN killswitch and it is available without the ne
 
 ## Global Toggles
 
-Modern Android devices have global toggles for disabling [Bluetooth](https://en.wikipedia.org/wiki/Bluetooth) and location services. Android 12 introduced toggles for the camera and microphone. When not in use, we recommend disabling these features. Apps cannot use disabled features (even if granted individual permission) until re-enabled.
+Modern Android devices have global toggles for disabling Bluetooth and location services. Android 12 introduced toggles for the camera and microphone. When not in use, we recommend disabling these features. Apps cannot use disabled features (even if granted individual permission) until re-enabled.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -95,7 +95,7 @@ You can still stay logged into websites by allowing exceptions.
 
 #### Sync
 
-The [Firefox Sync](https://hacks.mozilla.org/2018/11/firefox-sync-privacy/) service is end-to-end encrypted.
+The [Firefox Sync](https://hacks.mozilla.org/2018/11/firefox-sync-privacy/) service uses E2EE.
 
 #### Extensions
 
@@ -191,7 +191,7 @@ Open Safari and press the tabs icon in the bottom right corner. Open Tab Groups,
 
 #### iCloud Sync
 
-While synchronization of Safari History, Tab Groups, and iCloud Tabs is end-to-end encrypted, bookmarks are [not](https://support.apple.com/en-us/HT202303); they are only encrypted in transit and stored in an encrypted format on Apple's servers. Apple may be able to decrypt and access them.
+While synchronization of Safari History, Tab Groups, and iCloud Tabs uses E2EE, bookmarks sync does [not](https://support.apple.com/en-us/HT202303); they are only encrypted in transit and stored in an encrypted format on Apple's servers. Apple may be able to decrypt and access them.
 
 If you use iCloud, we also recommend checking to ensure Safari's default download location is set to locally on your device. This option can be found in *General* (⚙️ Settings → Safari → General → Downloads).
 
@@ -260,3 +260,5 @@ There is also [AdGuard for iOS](https://adguard.com/en/adguard-ios/overview.html
     **Terms of Service; Didn't Read** grades websites based on their terms of service agreements and privacy policies. It also gives short summaries of those agreements. The analyses and ratings are published transparently by a community of reviewers.
 
     [Visit tosdr.org](https://tosdr.org){ .md-button .md-button--primary } [Privacy Policy](https://addons.mozilla.org/firefox/addon/terms-of-service-didnt-read/privacy){ .md-button }
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/calendar-contacts.en.md
+++ b/docs/calendar-contacts.en.md
@@ -2,11 +2,11 @@
 title: "Calendar and Contact Sync"
 icon: material/calendar
 ---
-Calendaring and contacts are some of the most sensitive data posess. Use only products that use end-to-end encryption (E2EE) at rest. This prevents a provider from reading your data.
+Calendaring and contacts are some of the most sensitive data posess. Use only products that use E2EE at rest. This prevents a provider from reading your data.
 
-## Software as a service (SaaS) only
+## Cloud/SaaS Providers
 
-These products are included with an subscription to the respective [email providers](email.md).
+These products are included with an subscription with their respective [email providers](email.md).
 
 ### Tutanota
 
@@ -45,7 +45,7 @@ These products are included with an subscription to the respective [email provid
 
 ## Self-hostable
 
-Some of these options are self-hostable, or able to be hosted by third party providers for a fee:
+Some of these options are self-hostable, but could be offered by third party SaaS providers for a fee:
 
 ### EteSync
 
@@ -104,3 +104,5 @@ Some of these options are self-hostable, or able to be hosted by third party pro
     - [:fontawesome-brands-google-play: Google Play](https://play.google.com/store/apps/details?id=org.decsync.cc)
     - [:pg-f-droid: F-Droid](https://f-droid.org/packages/org.decsync.cc)
     - [:fontawesome-brands-github: Source](https://github.com/39aldo39/DecSync)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/cloud.en.md
+++ b/docs/cloud.en.md
@@ -4,7 +4,7 @@ icon: material/file-cloud
 ---
 If you are currently using a Cloud Storage Service like Dropbox, Google Drive, Microsoft OneDrive or Apple iCloud, you are putting complete trust in your service provider to not look at your files.
 
-Trust your provider by using an alternative below that supports [end-to-end encryption (E2EE)](https://wikipedia.org/wiki/End-to-end_encryption).
+Trust your provider by using an alternative below that supports E2EE.
 
 ### Nextcloud
 
@@ -12,7 +12,7 @@ Trust your provider by using an alternative below that supports [end-to-end encr
 
     ![Nextcloud logo](assets/img/cloud/nextcloud.svg){ align=right }
 
-    **Nextcloud** is a suite of free and open-source client-server software for creating your own file hosting services on a private server you control. It also comes with experimental end-to-end encryption (E2EE).
+    **Nextcloud** is a suite of free and open-source client-server software for creating your own file hosting services on a private server you control. It also comes with experimental E2EE.
 
     [Visit nextcloud.com](https://nextcloud.com){ .md-button .md-button--primary } [Privacy Policy](https://nextcloud.com/privacy){ .md-button }
 
@@ -38,7 +38,7 @@ When self hosting Nextcloud, you should also remember to enable E2EE to protect 
 
     ![Proton Drive logo](assets/img/cloud/protondrive.svg){ align=right }
 
-    **Proton Drive** is an end-to-end encrypted (E2EE) general file storage service by the popular encrypted email provider [ProtonMail](https://protonmail.com).
+    **Proton Drive** is an E2EE general file storage service by the popular encrypted email provider [ProtonMail](https://protonmail.com).
 
     [Visit drive.protonmail.com](https://drive.protonmail.com){ .md-button .md-button--primary } [Privacy Policy](https://protonmail.com/privacy-policy){ .md-button }
 
@@ -84,3 +84,5 @@ When using a web client, you are placing trust in the server to send you proper 
     - [:fontawesome-brands-linux: Linux](https://github.com/tahoe-lafs/tahoe-lafs#using-os-packages)
     - [:pg-netbsd: NetBSD](https://pkgsrc.se/filesystems/tahoe-lafs)
     - [:fontawesome-brands-git: Source](https://www.tahoe-lafs.org/trac/tahoe-lafs/browser)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/dns.en.md
+++ b/docs/dns.en.md
@@ -120,3 +120,5 @@ Encrypted DNS proxy software provides a local proxy for the [unencrypted DNS](te
     - [:fontawesome-brands-github: Source](https://github.com/DNSCrypt/dnscrypt-proxy)
 
 !!! warning "The anonymized DNS feature does [**not**](technology/dns.md#why-shouldnt-i-use-encrypted-dns) anonymize other network traffic."
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/email-clients.en.md
+++ b/docs/email-clients.en.md
@@ -136,7 +136,7 @@ Our recommendation list contains email clients that support both [OpenPGP](encry
 
     Canary Mail only recently released a Windows and Android client, we don't believe they are as stable as their iOS and Mac counterparts.
 
-Canary Mail is closed source. We recommend it, due to the few choices there are for email clients on iOS that support [Pretty Good Privacy (PGP)](https://en.wikipedia.org/wiki/Pretty_Good_Privacy), end-to-end encryption (E2EE).
+Canary Mail is closed source. We recommend it, due to the few choices there are for email clients on iOS that support [Pretty Good Privacy (PGP)](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) E2EE.
 
 ### NeoMutt
 
@@ -154,3 +154,5 @@ Canary Mail is closed source. We recommend it, due to the few choices there are 
     - [:fontawesome-brands-linux: Linux](https://neomutt.org/distro)
     - [:fontawesome-brands-apple: macOS](https://neomutt.org/distro)
     - [:fontawesome-brands-github: Source](https://github.com/neomutt/neomutt)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/email.en.md
+++ b/docs/email.en.md
@@ -7,7 +7,7 @@ Find a secure email provider that will keep your privacy in mind. Don’t settle
 
 !!! warning
 
-    When using end-to-end encryption (E2EE) technology like OpenPGP, email will still have some metadata that is not encrypted in the header of the email. Read more about email metadata.
+    When using E2EE technology like OpenPGP, email will still have some metadata that is not encrypted in the header of the email. Read more about email metadata.
 
     OpenPGP also does not support Forward secrecy, which means if either your or the recipient's private key is ever stolen, all previous messages encrypted with it will be exposed. How do I protect my private keys?
 
@@ -43,7 +43,7 @@ Find a secure email provider that will keep your privacy in mind. Don’t settle
 
 ??? check "Account Security"
 
-    ProtonMail supports [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm) [two factor authentication](https://protonmail.com/support/knowledge-base/two-factor-authentication/) only. The use of a [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) security key is not yet supported. ProtonMail is planning to implement U2F upon completion of their [Single Sign On (SSO)](https://reddit.com/comments/cheoy6/comment/feh2lw0/) code.
+    ProtonMail supports TOTP [two factor authentication](https://protonmail.com/support/knowledge-base/two-factor-authentication/) only. The use of a U2F security key is not yet supported. ProtonMail is planning to implement U2F upon completion of their [Single Sign On (SSO)](https://reddit.com/comments/cheoy6/comment/feh2lw0/) code.
 
 ??? check "Data Security"
 
@@ -85,7 +85,7 @@ Find a secure email provider that will keep your privacy in mind. Don’t settle
 
 ??? check "Account Security"
 
-    Mailbox.org supports [two factor authentication](https://kb.mailbox.org/display/MBOKBEN/How+to+use+two-factor+authentication+-+2FA) for their webmail only. You can use either [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm) or a [Yubikey](https://en.wikipedia.org/wiki/YubiKey) via the [Yubicloud](https://www.yubico.com/products/services-software/yubicloud). Web standards such as [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn) are not yet supported.
+    Mailbox.org supports [two factor authentication](https://kb.mailbox.org/display/MBOKBEN/How+to+use+two-factor+authentication+-+2FA) for their webmail only. You can use either TOTP or a [Yubikey](https://en.wikipedia.org/wiki/YubiKey) via the [Yubicloud](https://www.yubico.com/products/services-software/yubicloud). Web standards such as [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn) are not yet supported.
 
 ??? info "Data Security"
 
@@ -130,11 +130,11 @@ Find a secure email provider that will keep your privacy in mind. Don’t settle
 
 ??? check "Account Security"
 
-    Disroot supports [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm) two factor authentication for webmail only. They do not allow [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) security key authentication.
+    Disroot supports TOTP two factor authentication for webmail only. They do not allow U2F security key authentication.
 
 ??? warning "Data Security"
 
-    Disroot uses full disk encryption. However, it doesn't appear to be "zero access", meaning it is technically possible for them to decrypt the data they have if it is not additionally encrypted with a tool like OpenPGP.
+    Disroot uses FDE. However, it doesn't appear to be "zero access", meaning it is technically possible for them to decrypt the data they have if it is not additionally encrypted with a tool like OpenPGP.
 
     Disroot also uses the standard [CalDAV](https://en.wikipedia.org/wiki/CalDAV) and [CardDAV](https://en.wikipedia.org/wiki/CardDAV) protocols for calendars and contacts, which do not support E2EE. A [standalone option](calendar-contacts.md) may be more appropriate.
 
@@ -163,7 +163,7 @@ Find a secure email provider that will keep your privacy in mind. Don’t settle
 
     [Visit Tutanota.com](https://tutanota.com){ .md-button .md-button--primary }
 
-Tutanota [doesn't allow](https://tutanota.com/faq/#imap) the use of third-party [email clients](email-clients.md). Tutanota has no plans pull email from [external email accounts](https://github.com/tutao/tutanota/issues/544#issuecomment-670473647) using the [IMAP](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) protocol. [Email import](https://github.com/tutao/tutanota/issues/630) is currently not possible.
+Tutanota [doesn't allow](https://tutanota.com/faq/#imap) the use of third-party [email clients](email-clients.md). Tutanota has no plans pull email from [external email accounts](https://github.com/tutao/tutanota/issues/544#issuecomment-670473647) using the IMAP protocol. [Email import](https://github.com/tutao/tutanota/issues/630) is currently not possible.
 
 Emails can be exported [individually or by bulk selection](https://tutanota.com/howto#generalMail). Tutanota does not allow for [subfolders](https://github.com/tutao/tutanota/issues/927) as you might expect with other email providers.
 
@@ -179,7 +179,7 @@ Tutanota is working on a [desktop client](https://tutanota.com/blog/posts/deskto
 
 ??? check "Account Security"
 
-    Tutanota supports [two factor authentication](https://tutanota.com/faq#2fa). Users can either use [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm) or [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor). U2F support is [not yet available on Android](https://github.com/tutao/tutanota/issues/443).
+    Tutanota supports [two factor authentication](https://tutanota.com/faq#2fa). Users can either use TOTP or U2F. U2F support is [not yet available on Android](https://github.com/tutao/tutanota/issues/443).
 
 ??? check "Data Security"
 
@@ -224,7 +224,7 @@ Tutanota is working on a [desktop client](https://tutanota.com/blog/posts/deskto
 
 ??? check "Account Security"
 
-    StartMail supports [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm) two factor authentication [for webmail only](https://support.startmail.com/hc/en-us/articles/360006682158-Two-factor-authentication-2FA). They do not allow [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) security key authentication.
+    StartMail supports TOTP two factor authentication [for webmail only](https://support.startmail.com/hc/en-us/articles/360006682158-Two-factor-authentication-2FA). They do not allow U2F security key authentication.
 
 ??? info "Data Security"
 
@@ -267,7 +267,7 @@ Tutanota is working on a [desktop client](https://tutanota.com/blog/posts/deskto
 
 ??? check "Account Security"
 
-    CTemplar supports [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm) two factor authentication [for webmail only](https://ctemplar.com/help/answer/setting-up-two-factor-authentication-2fa/). They do not allow [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) security key authentication.
+    CTemplar supports TOTP two factor authentication [for webmail only](https://ctemplar.com/help/answer/setting-up-two-factor-authentication-2fa/). They do not allow U2F security key authentication.
 
 ??? check "Data Security"
 
@@ -315,7 +315,7 @@ We regard these features as important in order to provide a safe and optimal ser
 **Minimum to Qualify:**
 
 - Encrypts account data at rest.
-- Integrated webmail encryption provides convenience to users who want improve on having no [E2EE](https://en.wikipedia.org/wiki/End-to-end_encryption) encryption.
+- Integrated webmail encryption provides convenience to users who want improve on having no E2EE.
 
 **Best Case:**
 
@@ -327,7 +327,7 @@ We regard these features as important in order to provide a safe and optimal ser
 - Availability of the email provider's services via an [onion service](https://en.wikipedia.org/wiki/.onion).
 - [Subaddressing](https://en.wikipedia.org/wiki/Email_address#Subaddressing) support.
 - [Catch all](https://en.wikipedia.org/wiki/Email_filtering) or [aliases](https://en.wikipedia.org/wiki/Email_alias) for users who own their own domains.
-- Use of standard email access protocols such as [IMAP](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol), [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) or [JMAP](https://en.wikipedia.org/wiki/JSON_Meta_Application_Protocol). Standard access protocols ensure customers can easily download all of their email, should they want to switch to another provider.
+- Use of standard email access protocols such as IMAP, SMTP or [JMAP](https://en.wikipedia.org/wiki/JSON_Meta_Application_Protocol). Standard access protocols ensure customers can easily download all of their email, should they want to switch to another provider.
 
 ### Privacy
 
@@ -349,7 +349,7 @@ Email servers deal with a lot of very sensitive data. We expect that providers w
 
 **Minimum to Qualify:**
 
-- Protection of webmail with [two-factor authentication (2FA)](https://en.wikipedia.org/wiki/Multi-factor_authentication), such as [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm).
+- Protection of webmail with 2FA, such as TOTP.
 - Encryption at rest, (e.g. [dm-crypt](https://en.wikipedia.org/wiki/dm-crypt)) this protects the contents of the servers in case of unlawful seizure.
 - [DNSSEC](https://en.wikipedia.org/wiki/Domain_Name_System_Security_Extensions) support.
 - No [TLS](https://en.wikipedia.org/wiki/Opportunistic_TLS) errors/vulnerabilities when being profiled by tools such as [Hardenize](https://www.hardenize.com), [testssl.sh](https://testssl.sh) or [Qualys SSL Labs](https://www.ssllabs.com/ssltest), this includes certificate related errors, poor or weak ciphers suites, weak DH parameters such as those that led to [Logjam](https://en.wikipedia.org/wiki/Logjam_(computer_security)).
@@ -366,7 +366,7 @@ Email servers deal with a lot of very sensitive data. We expect that providers w
 
 **Best Case:**
 
-- Support for hardware authentication, ie [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) and [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn). U2F and WebAuthn are more secure as they use a private key stored on a client-side hardware device to authenticate users, as opposed to a shared secret that is stored on the web server and on the client side when using TOTP. Furthermore, U2F and WebAuthn are more resistant to phishing as their authentication response is based on the authenticated [domain name](https://en.wikipedia.org/wiki/Domain_name).
+- Support for hardware authentication, ie U2F and [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn). U2F and WebAuthn are more secure as they use a private key stored on a client-side hardware device to authenticate users, as opposed to a shared secret that is stored on the web server and on the client side when using TOTP. Furthermore, U2F and WebAuthn are more resistant to phishing as their authentication response is based on the authenticated [domain name](https://en.wikipedia.org/wiki/Domain_name).
 - Zero access encryption, builds on encryption at rest. The difference being the provider does not have the decryption keys to the data they hold. This prevents a rogue employee leaking data they have access to or remote adversary from releasing data they have stolen by gaining unauthorized access to the server.
 - [DNS Certification Authority Authorization (CAA) Resource Record](https://tools.ietf.org/html/rfc6844) in addition to DANE support.
 - Implementation of [Authenticated Received Chain (ARC)](https://en.wikipedia.org/wiki/Authenticated_Received_Chain), this is useful for users who post to mailing lists [RFC8617](https://tools.ietf.org/html/rfc8617).
@@ -415,9 +415,9 @@ While not strictly requirements, there are some other convenience or privacy fac
 
 ## Email Encryption Overview
 
-### What is end-to-end encryption (E2EE) encryption in email?
+### What is end-to-end encryption (E2EE) in email?
 
-[End-to-end encryption (E2EE)](https://en.wikipedia.org/wiki/End-to-end_encryption) is a way of encrypting email contents so that nobody but the recipient(s) can read the email message.
+E2EE is a way of encrypting email contents so that nobody but the recipient(s) can read the email message.
 
 ### How can I encrypt my email?
 
@@ -427,7 +427,7 @@ There is another standard that was popular with business called [S/MIME](https:/
 
 ### What software can I use to get E2EE?
 
-Email providers which allow you to use standard access protocols like [IMAP](https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol) and [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) can be used with any of the [email clients we recommend](email-clients.md). This can be less secure as you are now relying on email providers to ensure that their encryption implementation works and has not been compromised in anyway.
+Email providers which allow you to use standard access protocols like IMAP and SMTP can be used with any of the [email clients we recommend](email-clients.md). This can be less secure as you are now relying on email providers to ensure that their encryption implementation works and has not been compromised in anyway.
 
 ### How do I protect my private keys?
 
@@ -504,3 +504,5 @@ For a more manual approach we've picked out these two articles.
 - [An NFC PGP SmartCard For Android](https://www.grepular.com/An_NFC_PGP_SmartCard_For_Android)
 - [Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops (2011)](https://www.wired.com/2011/10/ecpa-turns-twenty-five/)
 - [The Government Can (Still) Read Most Of Your Emails Without A Warrant (2013)](https://thinkprogress.org/the-government-can-still-read-most-of-your-emails-without-a-warrant-322fe6defc7b/)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/encryption.en.md
+++ b/docs/encryption.en.md
@@ -69,9 +69,9 @@ Some of the Cryptomator Crypto Libraries have been [audited](https://cryptomator
     - [:fontawesome-brands-linux: Linux](https://github.com/HACKERALERT/Picocrypt/releases)
     - [:fontawesome-brands-github: Source](https://github.com/HACKERALERT/Picocrypt)
 
-## Operating system included Full Disk Encryption (FDE)
+## OS Full Disk Encryption
 
-Modern operating systems include [disk encryption](https://en.wikipedia.org/wiki/Disk_encryption) and will utilize a [secure cryptoprocessor](https://en.wikipedia.org/wiki/Secure_cryptoprocessor).
+Modern operating systems include [FDE](https://en.wikipedia.org/wiki/Disk_encryption) and will utilize a [secure cryptoprocessor](https://en.wikipedia.org/wiki/Secure_cryptoprocessor).
 
 ### BitLocker
 
@@ -130,13 +130,13 @@ BitLocker is [only supported](https://support.microsoft.com/en-us/windows/turn-o
 
 We recommend storing a local recovery key in a secure place as opposed to utilizing iCloud FileVault recovery. As well, FileVault should be enabled **after** a complete macOS installation as more pseudorandom number generator ([PRNG](https://support.apple.com/guide/security/random-number-generation-seca0c73a75b/web)) [entropy](https://en.wikipedia.org/wiki/Entropy_(computing)) will be available.
 
-### Linux Unified Key Setup (LUKS)
+### Linux Unified Key Setup
 
 !!! recommendation
 
     ![LUKS logo](assets/img/encryption-software/luks.png){ align=right }
 
-    **LUKS** is the default full disk encryption method for Linux. It can be used to encrypt full volumes, partitions, or create encrypted containers.
+    **LUKS** is the default FDE method for Linux. It can be used to encrypt full volumes, partitions, or create encrypted containers.
 
     [Visit gitlab.com](https://gitlab.com/cryptsetup/cryptsetup){ .md-button .md-button--primary }
 
@@ -292,3 +292,5 @@ When encrypting with PGP, the user has the option to configure different options
     - [:fontawesome-brands-google-play: Google Play](https://play.google.com/store/apps/details?id=org.sufficientlysecure.keychain)
     - [:pg-f-droid: F-Droid](https://f-droid.org/packages/org.sufficientlysecure.keychain/)
     - [:fontawesome-brands-git: Source](https://github.com/open-keychain/open-keychain)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/linux-desktop.en.md
+++ b/docs/linux-desktop.en.md
@@ -199,7 +199,7 @@ We strongly recommend **against** using the Linux-libre kernel, since it [remove
 
 ### Drive Encryption
 
-Most Linux distributions have an installer option for enabling [Linux Unified Key Setup (LUKS)](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) encryption upon installation.
+Most Linux distributions have an installer option for enabling [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) FDE upon installation.
 
 If this option isn’t set at installation time, the user will have to backup their data and re-install, as encryption is applied after [disk partitioning](https://en.wikipedia.org/wiki/Disk_partitioning) but before [file systems](https://en.wikipedia.org/wiki/File_system) are [formatted](https://en.wikipedia.org/wiki/Disk_formatting).
 

--- a/docs/metadata-removal-tools.en.md
+++ b/docs/metadata-removal-tools.en.md
@@ -2,7 +2,7 @@
 title: "Metadata Removal Tools"
 icon: material/tag-remove
 ---
-When sharing files, be sure to remove associated metadata. Image files commonly include [EXIF](https://en.wikipedia.org/wiki/Exif) data. Photos sometimes even include [GPS](https://en.wikipedia.org/wiki/Global_Positioning_System) coordinates in the file metadata.
+When sharing files, be sure to remove associated metadata. Image files commonly include [Exif](https://en.wikipedia.org/wiki/Exif) data. Photos sometimes even include GPS coordinates in the file metadata.
 
 ## Desktop
 
@@ -31,7 +31,7 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
 
     ![ExifCleaner logo](assets/img/metadata-removal/exifcleaner.svg){ align=right }
 
-    **ExifCleaner** is a freeware, open source graphical app that uses [ExifTool](https://exiftool.org) to remove EXIF metadata from images, videos, and PDF documents using a simple drag and drop interface. It supports multi-core batch processing and dark mode.
+    **ExifCleaner** is a freeware, open source graphical app that uses [ExifTool](https://exiftool.org) to remove Exif metadata from images, videos, and PDF documents using a simple drag and drop interface. It supports multi-core batch processing and dark mode.
 
     [Visit exifcleaner.com](https://exifcleaner.com){ .md-button .md-button--primary }
 
@@ -49,7 +49,7 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
 
     ![Scrambled Exif logo](assets/img/metadata-removal/scrambled-exif.svg){ align=right }
 
-    **Scrambled Exif** is a metadata removal tool for Android. It can remove EXIF data for many file formats and has been translated into [many](https://gitlab.com/juanitobananas/scrambled-exif/-/tree/master/app/src/main/res) languages.
+    **Scrambled Exif** is a metadata removal tool for Android. It can remove Exif data for many file formats and has been translated into [many](https://gitlab.com/juanitobananas/scrambled-exif/-/tree/master/app/src/main/res) languages.
 
     [Visit gitlab.com](https://gitlab.com/juanitobananas/scrambled-exif){ .md-button .md-button--primary }
 
@@ -68,7 +68,7 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
 
     ![Imagepipe logo](assets/img/metadata-removal/imagepipe.svg){ align=right }
 
-    **Imagepipe** is a a paint app for Android that can be used to redact photos and also delete EXIF metadata. It has been translated into [many](https://codeberg.org/Starfish/Imagepipe#translations) languages.
+    **Imagepipe** is a a paint app for Android that can be used to redact photos and also delete Exif metadata. It has been translated into [many](https://codeberg.org/Starfish/Imagepipe#translations) languages.
 
     [Visit codeberg.org](https://codeberg.org/Starfish/Imagepipe){ .md-button .md-button--primary }
 
@@ -101,9 +101,9 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
 
     ![ExifTool logo](assets/img/metadata-removal/exiftool.png){ align=right }
 
-    **ExifTool** is the original perl library and command-line application for reading, writing, and editing meta information (EXIF, IPTC, XMP, and more) in a wide variety of file formats (JPEG, TIFF, PNG, PDF, RAW, and more).
+    **ExifTool** is the original perl library and command-line application for reading, writing, and editing meta information (Exif, IPTC, XMP, and more) in a wide variety of file formats (JPEG, TIFF, PNG, PDF, RAW, and more).
 
-    It's often a component of other EXIF removal applications and is in most Linux distribution repositories.
+    It's often a component of other Exif removal applications and is in most Linux distribution repositories.
 
     [Visit exiftool.org](https://exiftool.org){ .md-button .md-button--primary }
 
@@ -119,3 +119,5 @@ To delete data from a directory of files:
 ```bash
 exiftool -all= *.file_extension
 ```
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/multi-factor-authentication.en.md
+++ b/docs/multi-factor-authentication.en.md
@@ -92,3 +92,5 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
     - [:fontawesome-brands-app-store-ios: App Store](https://apps.apple.com/us/app/raivo-otp/id1459042137)
     - [:fontawesome-brands-app-store: Mac App Store](https://apps.apple.com/us/app/raivo-otp/id1498497896)
     - [:fontawesome-brands-github: GitHub](https://github.com/raivo-otp/ios-application)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/notebooks.en.md
+++ b/docs/notebooks.en.md
@@ -5,7 +5,7 @@ icon: material/notebook-edit-outline
 
 Keep track of your notes and journalings without giving them to a third party.
 
-If you are currently using an application like Evernote, Google Keep, or Microsoft OneNote, we suggest you pick an alternative here that supports [End-to-end encryption (E2EE)](https://en.wikipedia.org/wiki/End-to-end_encryption).
+If you are currently using an application like Evernote, Google Keep, or Microsoft OneNote, we suggest you pick an alternative here that supports E2EE.
 
 ## Cloud based
 
@@ -15,7 +15,7 @@ If you are currently using an application like Evernote, Google Keep, or Microso
 
     ![Joplin logo](assets/img/notebooks/joplin.svg){ align=right }
 
-    **Joplin** is a free, open-source, and fully-featured note-taking and to-do application which can handle a large number of markdown notes organized into notebooks and tags. It offers end-to-end encryption and can sync through Nextcloud, Dropbox, and more. It also offers easy import from Evernote and plain-text notes.
+    **Joplin** is a free, open-source, and fully-featured note-taking and to-do application which can handle a large number of markdown notes organized into notebooks and tags. It offers E2EE and can sync through Nextcloud, Dropbox, and more. It also offers easy import from Evernote and plain-text notes.
 
     [Visit joplinapp.org](https://joplinapp.org/){ .md-button .md-button--primary }
 
@@ -40,7 +40,7 @@ If you are currently using an application like Evernote, Google Keep, or Microso
 
     ![Standard Notes logo](assets/img/notebooks/standard-notes.svg){ align=right }
 
-    Standard Notes is a simple and private notes app that makes your notes easy and available everywhere you are. It features end-to-end encryption on every platform, and a powerful desktop experience with themes and custom editors. It has also been [independently audited (PDF)](https://s3.amazonaws.com/standard-notes/security/Report-SN-Audit.pdf).
+    Standard Notes is a simple and private notes app that makes your notes easy and available everywhere you are. It features E2EE on every platform, and a powerful desktop experience with themes and custom editors. It has also been [independently audited (PDF)](https://s3.amazonaws.com/standard-notes/security/Report-SN-Audit.pdf).
 
     [Visit standardnotes.org](https://standardnotes.org/){ .md-button .md-button--primary }
 
@@ -58,3 +58,5 @@ If you are currently using an application like Evernote, Google Keep, or Microso
 - [EteSync](https://www.etesync.com/) - Secure, end-to-end encrypted, and privacy respecting sync for your contacts, calendars, tasks and notes.
 - [Paperwork](https://paperwork.cloud/) - An open-source and self-hosted solution. For PHP / MySQL servers.
 - [Org-mode](https://orgmode.org) - A major mode for GNU Emacs. Org-mode is for keeping notes, maintaining TODO lists, planning projects, and authoring documents with a fast and effective plain-text system.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/passwords.en.md
+++ b/docs/passwords.en.md
@@ -8,7 +8,7 @@ Stay safe and secure online with an encrypted and open-source password manager.
 
 - Always use unique passwords. Don't make yourself a victim of "[credential stuffing](https://en.wikipedia.org/wiki/Credential_stuffing)".
 - Store an exported backup of your passwords in an [encrypted container](encryption.md) on another storage device. This can be useful if something happens to your device or the service you are using.
-- If possible, store [Time-based one-time password (TOTP)](https://en.wikipedia.org/wiki/Time-based_one-time_password) tokens in a separate [TOTP app](security/multi-factor-authentication.md#authenticator-apps) and not your password manager. TOTP codes are generated from a "[shared secret](https://en.wikipedia.org/wiki/Time-based_one-time_password#Security)". If the secret is obtained by an adversary they can generate TOTP values. Typically, mobile platforms have better app isolation and more secure methods for storing sensitive credentials.
+- If possible, store TOTP tokens in a separate [TOTP app](security/multi-factor-authentication.md#authenticator-apps) and not your password manager. TOTP codes are generated from a "[shared secret](https://en.wikipedia.org/wiki/Time-based_one-time_password#Security)". If the secret is obtained by an adversary they can generate TOTP values. Typically, mobile platforms have better app isolation and more secure methods for storing sensitive credentials.
 
 ## Local Password Managers
 
@@ -152,3 +152,5 @@ These products are minimal password managers that can be used within scripting a
     - [:fontawesome-brands-linux: Linux](https://www.gopass.pw/#install-linux)
     - [:fontawesome-brands-freebsd: FreeBSD](https://www.gopass.pw/#install-bsd)
     - [:fontawesome-brands-github: Source](https://github.com/gopasspw/gopass)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/real-time-communication.en.md
+++ b/docs/real-time-communication.en.md
@@ -160,11 +160,11 @@ When self-hosted, users of a federated server can discover and communicate with 
 - Federated servers generally require trusting your server's administrator. They may be a hobbyist or otherwise not a "security professional," and may not serve standard documents like a privacy policy or terms of service detailing how your data is utilized.
 - Server administrators sometimes choose to block other servers, which are a source of unmoderated abuse or break general rules of accepted behavior. This will hinder your ability to communicate with users on those servers.
 
-### Peer-to-Peer (P2P) Networks
+### Peer-to-Peer Networks
 
 ![P2P diagram](assets/img/layout/network-distributed.svg){ align=left }
 
-[P2P](https://en.wikipedia.org/wiki/Peer-to-peer) messengers connect to a [distributed network](https://en.wikipedia.org/wiki/Distributed_networking) of nodes to relay a message to the recepient without a third-party server.
+P2P messengers connect to a [distributed network](https://en.wikipedia.org/wiki/Distributed_networking) of nodes to relay a message to the recepient without a third-party server.
 
 Clients (peers) usually find each other through the use of a [distributed computing](https://en.wikipedia.org/wiki/Distributed_computing) network. Examples of this include [Distributed Hash Tables](https://en.wikipedia.org/wiki/Distributed_hash_table) (DHT), used by [torrents](https://en.wikipedia.org/wiki/BitTorrent_(protocol)) and [IPFS](https://en.wikipedia.org/wiki/InterPlanetary_File_System) for example. Another approach is proximity based networks, where a connection is established over WiFi or Bluetooth (for example, Briar or the [Scuttlebutt](https://www.scuttlebutt.nz) social network protocol).
 
@@ -175,7 +175,7 @@ P2P networks do not use servers, as users communicate directly between each othe
 **Advantages:**
 
 - Minimal information is exposed to third parties.
-- Modern P2P platforms implement end-to-end encryption by default. There are no servers that could potentially intercept and decrypt your transmissions, unlike centralized and federated models.
+- Modern P2P platforms implement E2EE by default. There are no servers that could potentially intercept and decrypt your transmissions, unlike centralized and federated models.
 
 **Disadvantages:**
 
@@ -183,7 +183,7 @@ P2P networks do not use servers, as users communicate directly between each othe
 - Messages can only be sent when both peers are online, however, your client may store messages locally to wait for the contact to return online.
 - Generally increases battery usage on mobile devices, because the client must stay connected to the distributed network to learn about who is online.
 - Some common messenger features may not be implemented or incompletely, such as message deletion.
-- Your [IP address](https://en.wikipedia.org/wiki/IP_address) and that of the contacts you're communicating with may be exposed if you do not use the software in conjunction with a [VPN](vpn.md) or [self contained network](self-contained-networks.md), such as [Tor](https://www.torproject.org) or [I2P](https://geti2p.net/). Many countries have some form of mass surveillance and/or metadata retention.
+- Your IP address and that of the contacts you're communicating with may be exposed if you do not use the software in conjunction with a [VPN](vpn.md) or [self contained network](self-contained-networks.md), such as [Tor](https://www.torproject.org) or [I2P](https://geti2p.net/). Many countries have some form of mass surveillance and/or metadata retention.
 
 ### Anonymous Routing
 
@@ -207,3 +207,5 @@ Self-hosting a node in an anonymous routing network does not provide the hoster 
 - Less reliable if nodes are selected by randomized routing, some nodes may be very far from the sender and receiver, adding latency or even failing to transmit messages if one of the nodes goes offline.
 - More complex to get started as the creation and secured backup of a cryptographic private key is required.
 - Just like other decentralized platforms, adding features is more complex for developers than on a centralized platform, hence features may be lacking or incompletely implemented, such as offline message relaying or message deletion.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/router.en.md
+++ b/docs/router.en.md
@@ -34,3 +34,5 @@ Below are a few alternative operating systems, that can be used on routers, Wi-F
 
     **Downloads**
     - [:fontawesome-brands-github: Source](https://github.com/pfsense)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/search-engines.en.md
+++ b/docs/search-engines.en.md
@@ -74,3 +74,5 @@ Searx is a proxy between the user and the search engines it aggregates from. You
 When self-hosting, it is important that you have other people using your instance as well in order for you to blend in. You should be careful with where and how you are hosting Searx, as other people looking up illegal content on your instance could draw unwanted attention from authorities.
 
 When you are using a Searx instance, be sure to go read the Privacy Policy of that specific instance. Searx instances can be modified by their owners and therefore may not reflect their associated privacy policy. Some instances have Tor .onion addresses which may grant some privacy as long as your search queries don't contain PII (Personally Identifiable Information).
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/security/multi-factor-authentication.en.md
+++ b/docs/security/multi-factor-authentication.en.md
@@ -2,29 +2,29 @@
 title: "Multi-factor Authentication"
 icon: 'material/two-factor-authentication'
 ---
-**Multi-factor authentication** (MFA, or 2FA) is a security mechanism that requires additional steps beyond entering your username (or email) and password. The most common method is time limited codes you might receive from an SMS or app.
+**Multi-factor authentication** is a security mechanism that requires additional steps beyond entering your username (or email) and password. The most common method is time limited codes you might receive from an SMS or app.
 
 Normally, if a hacker (or adversary) is able to figure out your password then they’d gain access to the account that password belongs to. An account with MFA forces the hacker to have both the password (something you *know*) and a device that you own (something you *have*), like your phone.
 
-MFA methods vary in security, but are based on the premise that the more difficult it is for an attacker to gain access to your MFA method, the better. Examples of MFA methods (from weakest to strongest) include [SMS, Email codes](#sms-or-email-mfa), app push notifications, [Time-based One-time Passwords (TOTP)](#time-based-one-time-password-totp), [Yubico OTP](#yubico-otp), and [FIDO (Fast IDentity Online)](#fido-fast-identity-online).
+MFA methods vary in security, but are based on the premise that the more difficult it is for an attacker to gain access to your MFA method, the better. Examples of MFA methods (from weakest to strongest) include SMS, Email codes, app push notifications, TOTP, Yubico OTP, and FIDO.
 
 ## MFA Method Comparison
 
 ### SMS or Email MFA
 
-Receiving codes either from [**SMS**](https://en.wikipedia.org/wiki/One-time_password#SMS) or **email** are one of the weaker ways to secure your accounts with MFA. Obtaining a code by email or SMS takes away from the "something you *have*" idea, because there are a variety of ways a hacker could [take over your phone number](https://en.wikipedia.org/wiki/SIM_swap_scam) or gain access to your email without having physical access to any of your devices at all. If an unauthorized person gained access to your email, they would be able to use that access to both reset your password and receive the authentication code, giving them full access to your account.
+Receiving OTP codes via SMS or email are one of the weaker ways to secure your accounts with MFA. Obtaining a code by email or SMS takes away from the "something you *have*" idea, because there are a variety of ways a hacker could [take over your phone number](https://en.wikipedia.org/wiki/SIM_swap_scam) or gain access to your email without having physical access to any of your devices at all. If an unauthorized person gained access to your email, they would be able to use that access to both reset your password and receive the authentication code, giving them full access to your account.
 
 ### Push Notifications
 
-**Push notifications** take the form of a message being sent to an app on your phone asking you to confirm new account logins. This method is a lot better than SMS or email, since an attacker typically wouldn't be able to get these push notifications without having an already logged-in device, which means they would need to compromise one of your other devices first.
+Push notification MFA takes the form of a message being sent to an app on your phone asking you to confirm new account logins. This method is a lot better than SMS or email, since an attacker typically wouldn't be able to get these push notifications without having an already logged-in device, which means they would need to compromise one of your other devices first.
 
 We all make mistakes, and there is the risk that a user may accept the login attempt by accident. Push notification login authorizations are typically sent to *all* your devices at once, widening the availability of the MFA code if you have many devices.
 
-The security of push notification MFA is dependent on both the quality of the app, the server component and the trust of the developer who produces it. Installing an app may also require you to accept invasive privileges that grant access to other data on your device. An individual app also requires that you have a specific app for each service which may not require a password to open, unlike a good [Time-based One-time Password (TOTP)](#time-based-one-time-password-totp) app.
+The security of push notification MFA is dependent on both the quality of the app, the server component and the trust of the developer who produces it. Installing an app may also require you to accept invasive privileges that grant access to other data on your device. An individual app also requires that you have a specific app for each service which may not require a password to open, unlike a good TOTP generator app.
 
 ### Time-based One-time Password (TOTP)
 
-**TOTP** is one of the most commons form of MFA available. When a user sets up TOTP they are generally required to scan a [QR Code](https://en.wikipedia.org/wiki/QR_code) which establishes a "[shared secret](https://en.wikipedia.org/wiki/Shared_secret)" with the service that they intend to use. The shared secret is secured inside of the authenticator app's data, and is sometimes protected by a password.
+TOTP is one of the most commons form of MFA available. When a user sets up TOTP they are generally required to scan a [QR Code](https://en.wikipedia.org/wiki/QR_code) which establishes a "[shared secret](https://en.wikipedia.org/wiki/Shared_secret)" with the service that they intend to use. The shared secret is secured inside of the authenticator app's data, and is sometimes protected by a password.
 
 The time-limited code is then derived from the shared secret and the current time. As the code is only valid for a short time, without access to the shared secret an adversary cannot generate new codes.
 
@@ -54,17 +54,17 @@ The service will then forward the one-time password to the Yubico OTP server for
   ![Yubico OTP](../assets/img/multi-factor-authentication/yubico-otp.png)
 </figure>
 
-There are some benefits and disadvantages to using Yubico OTP when compared to [TOTP](#time-based-one-time-password-totp).
+There are some benefits and disadvantages to using Yubico OTP when compared to TOTP.
 
-The Yubico validation server is a cloud based service, and users place trust in Yubico that they are storing data securely and not profiling users. The public ID associated with Yubico OTP is reused on every website and could be another avenue for third parties to profile the user. Like [TOTP](#time-based-one-time-password-totp), Yubico OTP does not provide phishing resistance.
+The Yubico validation server is a cloud based service, and users place trust in Yubico that they are storing data securely and not profiling users. The public ID associated with Yubico OTP is reused on every website and could be another avenue for third parties to profile the user. Like TOTP, Yubico OTP does not provide phishing resistance.
 
 If your threat model requires you to have different identities on different websites, **do not** use Yubico OTP with the same hardware security key across those websites as public ID is unique to each security key.
 
 #### FIDO (Fast IDentity Online)
 
-[FIDO](https://en.wikipedia.org/wiki/FIDO_Alliance) includes a number of standards, first there was [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) and then later [FIDO2](https://en.wikipedia.org/wiki/FIDO2_Project) with the web standard [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn).
+[FIDO](https://en.wikipedia.org/wiki/FIDO_Alliance) includes a number of standards, first there was U2F and then later [FIDO2](https://en.wikipedia.org/wiki/FIDO2_Project) which includes the web standard [WebAuthn](https://en.wikipedia.org/wiki/WebAuthn).
 
-U2F and FIDO2 refer to the [CTAP (Client to Authenticator Protocol)](https://en.wikipedia.org/wiki/Client_to_Authenticator_Protocol), which is the protocol between the security key and the computer, such as a laptop or phone. It complements WebAuthn which is the component used to authenticate with the "Relying Party", the website, you're trying to log in on.
+U2F and FIDO2 refer to the [Client to Authenticator Protocol](https://en.wikipedia.org/wiki/Client_to_Authenticator_Protocol), which is the protocol between the security key and the computer, such as a laptop or phone. It complements WebAuthn which is the component used to authenticate with the website (the "Relying Party") you're trying to log in on.
 
 WebAuthn is the most secure and private form of second factor authentication. While the user experience is similar to Yubico OTP, the key does not print out a one-time password and validate with a third party server. Instead it uses [public key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) for authentication.
 
@@ -108,13 +108,13 @@ When using TOTP with an authenticator app, be sure to back up your recovery keys
 
 ### Initial setup
 
-When buying a security key, it is important that you change the default credentials, setup password protection for the key, and enable touch confirmation if your key supports it. Products such as the [YubiKey](#yubico-otp) have multiple interfaces with separate credentials for each one of them, so you should go over each interface and set up protection as well.
+When buying a security key, it is important that you change the default credentials, setup password protection for the key, and enable touch confirmation if your key supports it. Products such as the YubiKey) have multiple interfaces with separate credentials for each one of them, so you should go over each interface and set up protection as well.
 
 ### Email and SMS
 
 If you have to use email for MFA, make sure that the email account itself is secured with a proper MFA method.
 
-If you use SMS MFA, use a carrier who will not switch your phone number to a new SIM card without account access, or use a dedicated VoIP number from a provider with similar security to avoid a [SIM swap](https://en.wikipedia.org/wiki/SIM_swap_scam) attack.
+If you use SMS MFA, use a carrier who will not switch your phone number to a new SIM card without account access, or use a dedicated VoIP number from a provider with similar security to avoid a [SIM swap attack](https://en.wikipedia.org/wiki/SIM_swap_scam).
 
 [MFA tools we recommend](../multi-factor-authentication.md){ .md-button }
 
@@ -143,9 +143,10 @@ The command will prevent an adversary from bypassing MFA when the computer boots
 ### Linux
 
 !!! warning
-    If the [hostname](https://en.wikipedia.org/wiki/Hostname) of your system changes (such as due to DHCP), you would be unable to login. It is vital that you setup a proper hostname for your computer before following this guide.
 
-The `pam_u2f` module on Linux can provide two factor authentication for user login on most popular Linux distributions. If you have a hardware security key that supports U2F, you can set up MFA authentication for your login. Yubico has a guide [Ubuntu Linux Login Guide - U2F](https://support.yubico.com/hc/en-us/articles/360016649099-Ubuntu-Linux-Login-Guide-U2F) which should work on any distribution. The package manager commands—such as "apt-get"—and package names may however differ. This guide does **not** apply to Qubes OS.
+    If the hostname of your system changes (such as due to DHCP), you would be unable to login. It is vital that you setup a proper hostname for your computer before following this guide.
+
+The `pam_u2f` module on Linux can provide two factor authentication for user login on most popular Linux distributions. If you have a hardware security key that supports U2F, you can set up MFA authentication for your login. Yubico has a guide [Ubuntu Linux Login Guide - U2F](https://support.yubico.com/hc/en-us/articles/360016649099-Ubuntu-Linux-Login-Guide-U2F) which should work on any distribution. The package manager commands—such as `apt-get`—and package names may however differ. This guide does **not** apply to Qubes OS.
 
 ### Qubes OS
 
@@ -159,8 +160,10 @@ SSH MFA could be set up using multiple different authentication methods that are
 
 #### Time-based One-time Password (TOTP)
 
-SSH MFA can also be set up using TOTP. DigitalOcean has provided a tutorial [How To Set Up Multi-Factor Authentication for SSH on Ubuntu 20.04](https://www.digitalocean.com/community/tutorials/how-to-set-up-multi-factor-authentication-for-ssh-on-ubuntu-20-04). Most things should be the same regardless of distribution, however the package manager commands—such as "apt-get"—and package names may differ.
+SSH MFA can also be set up using TOTP. DigitalOcean has provided a tutorial [How To Set Up Multi-Factor Authentication for SSH on Ubuntu 20.04](https://www.digitalocean.com/community/tutorials/how-to-set-up-multi-factor-authentication-for-ssh-on-ubuntu-20-04). Most things should be the same regardless of distribution, however the package manager commands—such as `apt-get`—and package names may differ.
 
 ### KeePass (and KeePassXC)
 
 KeePass and KeePassXC databases can be secured using Challenge-Response or HOTP as a second factor authentication. Yubico has provided a document for KeePass [Using Your YubiKey with KeePass](https://support.yubico.com/hc/en-us/articles/360013779759-Using-Your-YubiKey-with-KeePass) and there is also one on the [KeePassXC](https://keepassxc.org/docs/#faq-yubikey-2fa) website.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/self-contained-networks.en.md
+++ b/docs/self-contained-networks.en.md
@@ -12,7 +12,7 @@ If you are currently browsing clearnet and want to access the dark web, this sec
 
     ![Tor logo](assets/img/self-contained-networks/tor.svg){ align=right }
 
-    The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool.
+    The **Tor** network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool.
 
     [Visit torproject.org](https://www.torproject.org){ .md-button .md-button--primary } [:pg-tor:](http://2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion){ .md-button }
 
@@ -28,14 +28,14 @@ If you are currently browsing clearnet and want to access the dark web, this sec
     - [:fontawesome-brands-android: Android](https://www.torproject.org/download/#android)
     - [:fontawesome-brands-git: Source](https://gitweb.torproject.org/tor.git)
 
-### I2P Anonymous Network
+### Invisible Internet Project
 
 !!! recommendation
 
     ![I2P logo](assets/img/self-contained-networks/i2p.svg#only-light){ align=right }
     ![I2P logo](assets/img/self-contained-networks/i2p-dark.svg#only-dark){ align=right }
 
-    The Invisible Internet Project (I2P) is a computer network layer that allows applications to send messages to each other pseudonymously and securely. Uses include anonymous Web surfing, chatting, blogging, and file transfers. The software that implements this layer is called an I2P router and a computer running I2P is called an I2P node. The software is free and open-source and is published under multiple licenses.
+    **I2P** is a computer network layer that allows applications to send messages to each other pseudonymously and securely. Uses include anonymous Web surfing, chatting, blogging, and file transfers. The software that implements this layer is called an I2P router and a computer running I2P is called an I2P node. The software is free and open-source and is published under multiple licenses.
 
     [Visit geti2p.net](https://geti2p.net){ .md-button .md-button--primary } [:pg-i2p:](http://i2p-projekt.i2p){ .md-button }
 
@@ -57,7 +57,7 @@ If you are currently browsing clearnet and want to access the dark web, this sec
 
     ![Freenet logo](assets/img/self-contained-networks/freenet.svg){ align=right }
 
-    Freenet is a peer-to-peer platform for censorship-resistant communication. It uses a decentralized distributed data store to keep and deliver information, and has a suite of free software for publishing and communicating on the Web without fear of censorship. Both Freenet and some of its associated tools were originally designed by Ian Clarke, who defined Freenet's goal as providing freedom of speech on the Internet with strong anonymity protection.
+    **Freenet** is a peer-to-peer platform for censorship-resistant communication. It uses a decentralized distributed data store to keep and deliver information, and has a suite of free software for publishing and communicating on the Web without fear of censorship. Both Freenet and some of its associated tools were originally designed by Ian Clarke, who defined Freenet's goal as providing freedom of speech on the Internet with strong anonymity protection.
 
     [Visit freenetproject.org/](https://freenetproject.org){ .md-button .md-button--primary }
 
@@ -69,3 +69,5 @@ If you are currently browsing clearnet and want to access the dark web, this sec
     - [:pg-openbsd: OpenBSD](https://freenetproject.org/pages/download.html#gnulinux-posix)
     - [:pg-netbsd: NetBSD](https://freenetproject.org/pages/download.html#gnulinux-posix)
     - [:fontawesome-brands-github: Source](https://github.com/freenet/)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/setup/integrating-metadata-removal.en.md
+++ b/docs/setup/integrating-metadata-removal.en.md
@@ -161,3 +161,5 @@ Windows allows users to place files in a **SendTo** folder which then appear in 
 ### Using the shortcut
 
 1. Right click a supported file and choose **ExifTool.bat** within the *Send to* context menu.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/technology/dns.en.md
+++ b/docs/technology/dns.en.md
@@ -3,15 +3,15 @@ title: "Introduction to DNS"
 icon: material/dns
 ---
 
-The [Domain Name System (DNS)](https://en.wikipedia.org/wiki/Domain_Name_System) is the 'phonebook of the Internet'. DNS translates domain names to [IP](https://en.wikipedia.org/wiki/Internet_Protocol) addresses so browsers and other services can load Internet resources, through a decentralized network of servers.
+The [Domain Name System](https://en.wikipedia.org/wiki/Domain_Name_System) is the 'phonebook of the Internet'. DNS translates domain names to IP addresses so browsers and other services can load Internet resources, through a decentralized network of servers.
 
 ## What is DNS?
 
 When you visit a website, a numerical address is returned. For example, when you visit `privacyguides.org`, the address `192.98.54.105` is returned.
 
-DNS has existed since the [early days](https://en.wikipedia.org/wiki/Domain_Name_System#History) of the Internet. DNS requests made to and from DNS servers are **not** generally encrypted. In a residential setting, a customer is given servers by the [ISP](https://en.wikipedia.org/wiki/Internet_service_provider) via [Dynamic Host Configuration Protocol (DHCP)](https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol).
+DNS has existed since the [early days](https://en.wikipedia.org/wiki/Domain_Name_System#History) of the Internet. DNS requests made to and from DNS servers are **not** generally encrypted. In a residential setting, a customer is given servers by the ISP via [DHCP](https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol).
 
-Unencrypted DNS requests are able to be easily **surveilled** and **modified** in transit. In some parts of the world, ISPs are ordered to do primitive [DNS filtering](https://en.wikipedia.org/wiki/DNS_blocking). When a user requests the IP of a domain that is blocked, the server may not respond or may respond with a different IP address. As the DNS protocol is not encrypted, the ISP (or any network operator) can use [deep packet inspection (DPI)](https://en.wikipedia.org/wiki/Deep_packet_inspection) to monitor requests. ISPs can also block requests based on common characteristics, regardless of which DNS server is used. Unencrypted DNS always uses [port](https://en.wikipedia.org/wiki/Port_(computer_networking)) 53 and always uses the [User Datagram Protocol (UDP)](https://en.wikipedia.org/wiki/User_Datagram_Protocol).
+Unencrypted DNS requests are able to be easily **surveilled** and **modified** in transit. In some parts of the world, ISPs are ordered to do primitive [DNS filtering](https://en.wikipedia.org/wiki/DNS_blocking). When a user requests the IP address of a domain that is blocked, the server may not respond or may respond with a different IP address. As the DNS protocol is not encrypted, the ISP (or any network operator) can use [DPI](https://en.wikipedia.org/wiki/Deep_packet_inspection) to monitor requests. ISPs can also block requests based on common characteristics, regardless of which DNS server is used. Unencrypted DNS always uses [port](https://en.wikipedia.org/wiki/Port_(computer_networking)) 53 and always uses UDP.
 
 Below, we discuss and provide a tutorial to prove what an outside observer may see using regular unencrypted DNS and [encrypted DNS](#what-is-encrypted-dns).
 
@@ -23,7 +23,7 @@ Below, we discuss and provide a tutorial to prove what an outside observer may s
     tshark -w /tmp/dns.pcap udp port 53 and host 1.1.1.1 or host 8.8.8.8
     ```
 
-2. We can then use [`dig`](https://en.wikipedia.org/wiki/Dig_(command)) (Linux, MacOS etc) or [`nslookup`](https://en.wikipedia.org/wiki/Nslookup) (Windows) to send the DNS lookup to both servers. Software such as web browsers do these lookups automatically, unless they are configured to use [encrypted DNS](#what-is-encrypted-dns).
+2. We can then use [`dig`](https://en.wikipedia.org/wiki/Dig_(command)) (Linux, MacOS etc) or [`nslookup`](https://en.wikipedia.org/wiki/Nslookup) (Windows) to send the DNS lookup to both servers. Software such as web browsers do these lookups automatically, unless they are configured to use encrypted DNS.
 
     === "Linux, MacOS"
 
@@ -69,17 +69,17 @@ Encrypted DNS can refer to one of a number of protocols, the most common ones be
 
 ### DNSCrypt
 
-[**DNSCrypt**](https://en.wikipedia.org/wiki/DNSCrypt) was one of the first methods of encrypting DNS queries. The [protocol](https://en.wikipedia.org/wiki/DNSCrypt#Protocol) operates on [port 443](https://en.wikipedia.org/wiki/Well-known_ports) and works with both the [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) or [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol) transport protocols. DNSCrypt has never been submitted to the [Internet Engineering Task Force (IETF)](https://en.wikipedia.org/wiki/Internet_Engineering_Task_Force) nor has it gone through the [Request for Comments (RFC)](https://en.wikipedia.org/wiki/Request_for_Comments) process, so it has not been used widely outside of a few [implementations](https://dnscrypt.info/implementations). As a result, it has been largely replaced by the more popular [DNS over HTTPS (DoH)](#dns-over-https-doh).
+[**DNSCrypt**](https://en.wikipedia.org/wiki/DNSCrypt) was one of the first methods of encrypting DNS queries. DNSCrypt operates on port 443 and works with both the TCP or UDP transport protocols. DNSCrypt has never been submitted to the [Internet Engineering Task Force (IETF)](https://en.wikipedia.org/wiki/Internet_Engineering_Task_Force) nor has it gone through the [Request for Comments (RFC)](https://en.wikipedia.org/wiki/Request_for_Comments) process, so it has not been used widely outside of a few [implementations](https://dnscrypt.info/implementations). As a result, it has been largely replaced by the more popular [DNS over HTTPS](#dns-over-https-doh).
 
 ### DNS over TLS (DoT)
 
-[**DNS over TLS (DoT)**](https://en.wikipedia.org/wiki/DNS_over_TLS) is another method for encrypting DNS communication that is defined in [RFC 7858](https://datatracker.ietf.org/doc/html/rfc7858). Support was first implemented in [Android 9](https://en.wikipedia.org/wiki/Android_Pie), [iOS 14](https://en.wikipedia.org/wiki/IOS_14), and on Linux in [systemd-resolved](https://www.freedesktop.org/software/systemd/man/resolved.conf.html#DNSOverTLS=) in version 237. Preference in the industry has been moving away from DoT to [DNS over HTTPS](#dns-over-https-doh) in recent years, as DoT is a [complex protocol](https://dnscrypt.info/faq/) and has varying compliance to the RFC across the implementations that exist. DoT also operates on a dedicated port 853 and that can be blocked easily by restrictive firewalls.
+[**DNS over TLS**](https://en.wikipedia.org/wiki/DNS_over_TLS) is another method for encrypting DNS communication that is defined in [RFC 7858](https://datatracker.ietf.org/doc/html/rfc7858). Support was first implemented in Android 9, iOS 14, and on Linux in [systemd-resolved](https://www.freedesktop.org/software/systemd/man/resolved.conf.html#DNSOverTLS=) in version 237. Preference in the industry has been moving away from DoT to DoH in recent years, as DoT is a [complex protocol](https://dnscrypt.info/faq/) and has varying compliance to the RFC across the implementations that exist. DoT also operates on a dedicated port 853 which can be blocked easily by restrictive firewalls.
 
 ### DNS over HTTPS (DoH)
 
-[**DNS over HTTPS**](https://en.wikipedia.org/wiki/DNS_over_HTTPS) as defined in [RFC 8484](https://datatracker.ietf.org/doc/html/rfc8484) packages queries in the [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) protocol and provides security with [HTTPS](https://en.wikipedia.org/wiki/HTTPS). Support was first added in web browsers such as [Firefox 60](https://support.mozilla.org/en-US/kb/firefox-dns-over-https) and [Chrome 83](https://blog.chromium.org/2020/05/a-safer-and-more-private-browsing-DoH.html).
+[**DNS over HTTPS**](https://en.wikipedia.org/wiki/DNS_over_HTTPS) as defined in [RFC 8484](https://datatracker.ietf.org/doc/html/rfc8484) packages queries in the [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) protocol and provides security with HTTPS. Support was first added in web browsers such as Firefox 60 and Chrome 83.
 
-Native implementations showed up in [iOS 14](https://en.wikipedia.org/wiki/IOS_14), [macOS 11](https://en.wikipedia.org/wiki/MacOS_11), [Microsoft Windows](https://docs.microsoft.com/en-us/windows-server/networking/dns/doh-client-support), and Android 13 (however it won't be enabled [by default](https://android-review.googlesource.com/c/platform/packages/modules/DnsResolver/+/1833144)). General Linux desktop support is waiting on the systemd [implementation](https://github.com/systemd/systemd/issues/8639) so [installing third party software is still required](../dns.md#linux).
+Native implementation of DoH showed up in iOS 14, macOS 11, Microsoft Windows, and Android 13 (however it won't be enabled [by default](https://android-review.googlesource.com/c/platform/packages/modules/DnsResolver/+/1833144)). General Linux desktop support is waiting on the systemd [implementation](https://github.com/systemd/systemd/issues/8639) so [installing third party software is still required](../dns.md#linux).
 
 ## What can an outside party see?
 
@@ -139,7 +139,7 @@ Server Name Indication is typically used when a IP address hosts many websites. 
     wireshark -r /tmp/pg.pcap
     ```
 
-    We will see the [connection establishment](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_establishment), followed by the [TLS handshake](https://www.cloudflare.com/learning/ssl/what-happens-in-a-tls-handshake/) for the Privacy Guides website. Around frame 5. you'll see a "Client Hello".
+    We will see the connection establishment, followed by the TLS handshake for the Privacy Guides website. Around frame 5. you'll see a "Client Hello".
 
 5. Expand the triangle &#9656; next to each field:
 
@@ -151,7 +151,7 @@ Server Name Indication is typically used when a IP address hosts many websites. 
             ▸ Server Name Indication extension
     ```
 
-6. We can see the [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) value which discloses the website we are visiting. The `tshark` command can give you the value directly for all packets containing a SNI value:
+6. We can see the SNI value which discloses the website we are visiting. The `tshark` command can give you the value directly for all packets containing a SNI value:
 
     ```bash
     tshark -r /tmp/pg.pcap -Tfields -Y tls.handshake.extensions_server_name -e tls.handshake.extensions_server_name
@@ -163,7 +163,7 @@ Governments, in particular [China](https://www.zdnet.com/article/china-is-now-bl
 
 ### Online Certificate Status Protocol (OCSP)
 
-Another way your browser can disclose your browsing activities is with the [Online Certificate Status Protocol](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol). When visiting a [HTTPS](https://en.wikipedia.org/wiki/HTTPS) website, the browser might check to see if the [X.509](https://en.wikipedia.org/wiki/X.509) [certificate](https://en.wikipedia.org/wiki/Public_key_certificate) has been [revoked](https://en.wikipedia.org/wiki/Certificate_revocation_list). This is generally done through the [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) protocol, meaning it is **not** encrypted.
+Another way your browser can disclose your browsing activities is with the [Online Certificate Status Protocol](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol). When visiting a [HTTPS](https://en.wikipedia.org/wiki/HTTPS) website, the browser might check to see if the website's [certificate](https://en.wikipedia.org/wiki/Public_key_certificate) has been revoked. This is generally done through the HTTP protocol, meaning it is **not** encrypted.
 
 The OCSP request contains the certificate "[serial number](https://en.wikipedia.org/wiki/Public_key_certificate#Common_fields)", which is unique. It is sent to the "OCSP responder" in order to check its status.
 
@@ -281,7 +281,7 @@ Encrypted DNS with a 3rd party should only be used to get around redirects and b
 
 ## What is DNSSEC and when is it used?
 
-[Domain Name System Security Extensions (DNSSEC)](https://en.wikipedia.org/wiki/Domain_Name_System_Security_Extensions) is used to provide authenticity to the records being fetched from upstream DNS servers. It doesn't provide confidentiality, for that we use one of the [encrypted DNS](#what-is-encrypted-dns) protocols discussed above.
+[Domain Name System Security Extensions](https://en.wikipedia.org/wiki/Domain_Name_System_Security_Extensions) (DNSSEC) is used to provide authenticity to the records being fetched from upstream DNS servers. It doesn't provide confidentiality, for that we use one of the [encrypted DNS](#what-is-encrypted-dns) protocols discussed above.
 
 ## What is QNAME minimization?
 
@@ -293,6 +293,8 @@ Instead of sending the whole domain `privacyguides.org`, QNAME minimization mean
 
 The [EDNS Client Subnet](https://en.wikipedia.org/wiki/EDNS_Client_Subnet) is a method for a recursive DNS resolver to specify a [subnetwork](https://en.wikipedia.org/wiki/Subnetwork) for the [host or client](https://en.wikipedia.org/wiki/Client_(computing)) which is making the DNS query.
 
-It's intended to "speed up" delivery of data by giving the client an answer that belongs to a server that is close to them such as a [content delivery network (CDN)](https://en.wikipedia.org/wiki/Content_delivery_network), which are often used in video streaming and serving JavaScript web apps.
+It's intended to "speed up" delivery of data by giving the client an answer that belongs to a server that is close to them such as a [content delivery network](https://en.wikipedia.org/wiki/Content_delivery_network), which are often used in video streaming and serving JavaScript web apps.
 
 This feature does come at a privacy cost, as it tells the DNS server some information about the client's location.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/tools.en.md
+++ b/docs/tools.en.md
@@ -389,3 +389,5 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 </div>
 
 [Learn more :material-arrow-right:](video-streaming.md)
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/video-streaming.en.md
+++ b/docs/video-streaming.en.md
@@ -147,3 +147,5 @@ When you are using an Invidious instance, be sure to go read the Privacy Policy 
 When self-hosting, it is important that you have other people using your instance as well in order for you to blend in. You should be careful with where and how you are hosting Piped, as other peoples' usage will be linked to your hosting.
 
 When you are using a Piped instance, be sure to go read the Privacy Policy of that specific instance. Piped instances can be modified by their owners and therefore may not reflect their associated privacy policy.
+
+--8<-- "includes/abbreviations.en.md"

--- a/docs/vpn.en.md
+++ b/docs/vpn.en.md
@@ -368,3 +368,5 @@ For use cases like these, or if you have another compelling reason, the VPN prov
 - [NordVPN HTTP POST bug exposed customer information, no authentication required](https://www.zdnet.com/article/nordvpn-http-post-bug-exposed-sensitive-customer-information/) March 2020
 - [Row erupts over who to blame after NordVPN says: One of our servers was hacked via remote management tool](https://www.theregister.com/2019/10/21/nordvpn_security_issue/) October 2019
 - [VPN servers seized by Ukrainian authorities weren't encrypted and allowed authorities to impersonate Windscribe servers and capture and decrypt traffic passing through them](https://arstechnica.com/gadgets/2021/07/vpn-servers-seized-by-ukrainian-authorities-werent-encrypted/) July 2021
+
+--8<-- "includes/abbreviations.en.md"

--- a/includes/abbreviations.en.md
+++ b/includes/abbreviations.en.md
@@ -1,0 +1,48 @@
+<!-- markdownlint-disable -->
+*[AOSP]: Android Open Source Project
+*[AVB]: Android Verified Boot
+*[DNS]: Domain Name System
+*[DNSSEC]: Domain Name System Security Extensions
+*[DoH]: DNS over HTTPS
+*[DoT]: DNS over TLS
+*[ECS]: EDNS Client Subnet
+*[Exif]: Exchangeable image file format
+*[E2EE]: End-to-End Encryption/Encrypted
+*[FDE]: Full Disk Encryption
+*[FIDO]: Fast IDentity Online
+*[GnuPG]: GNU Privacy Guard (PGP implementation)
+*[GPG]: GNU Privacy Guard (PGP implementation)
+*[GPS]: Global Positioning System
+*[HTTP]: Hypertext Transfer Protocol
+*[HTTPS]: Hypertext Transfer Protocol Secure
+*[IMAP]: Internet Message Access Protocol
+*[IP]: Internet Protocol
+*[ISP]: Internet Service Provider
+*[ISPs]: Internet Service Providers
+*[I2P]: Invisible Internet Project
+*[LUKS]: Linux Unified Key Setup (Full-Disk Encryption)
+*[MFA]: Multi-Factor Authentication
+*[OCSP]: Online Certificate Status Protocol
+*[OEM]: Original Equipment Manufacturer
+*[OEMs]: Original Equipment Manufacturers
+*[OpenPGP]: Open-source implementation of Pretty Good Privacy (PGP)
+*[OS]: Operating System
+*[OTP]: One-Time Password
+*[OTPs]: One-Time Passwords
+*[PGP]: Pretty Good Privacy (see OpenPGP)
+*[P2P]: Peer-to-Peer
+*[QNAME]: Qualified Name
+*[SaaS]: Software as a Service (cloud software)
+*[SMS]: Short Message Service (standard text messaging)
+*[SMTP]: Simple Mail Transfer Protocol
+*[SNI]: Server Name Indication
+*[TCP]: Transmission Control Protocol
+*[TEE]: Trusted Execution Environment
+*[TLS]: Transport Layer Security
+*[TOTP]: Time-based One-Time Password
+*[UDP]: User Datagram Protocol
+*[U2F]: Universal 2nd Factor
+*[VoIP]: Voice over IP (Internet Protocol)
+*[VPN]: Virtual Private Network
+*[W3C]: World Wide Web Consortium
+*[2FA]: 2-Factor Authentication

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ theme:
         name: Switch to light mode
 watch:
   - theme
+  - includes
 
 plugins:
   - i18n:
@@ -88,9 +89,11 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.mark
   - pymdownx.tilde
+  - pymdownx.snippets
   - attr_list
   - md_in_html
   - meta
+  - abbr
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
This change:

- Adds support for abbreviations: https://squidfunk.github.io/mkdocs-material/reference/abbreviations/
- Makes use of abbreviations more consistently throughout the website