### PR TITLE
Set toc_depth of 4

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ markdown_extensions:
   - footnotes
   - toc:
       permalink: true
+      toc_depth: 4
 
 extra_javascript:
   - javascripts/mathjax.js


### PR DESCRIPTION
Since @dngray changed some bold text to h5 headers in #1085 (which was the right move) the table of contents sidebar is a bit cluttered (see https://www.privacyguides.org/browsers/ for example). This limits the toc to only go down to h4 so we can keep them without extraneous toc entries.

[old](https://user-images.githubusercontent.com/3637842/164943173-6c296284-c59f-40e6-81cb-bfd762ead7fb.png) vs [new](https://user-images.githubusercontent.com/3637842/164943177-7c7b6be8-7594-4365-88d7-9ef49fc436f5.png)
