### PR TITLE
Reduce the number of admonitions across the site

### DIFF
--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -8,8 +8,6 @@ These are our current web browser recommendations and settings. We recommend kee
 
 ### Tor Browser
 
-!!! anonyimity "This product provides anonymity"
-
 !!! recommendation
 
     ![Tor Browser logo](assets/img/browsers/tor.svg){ align=right }
@@ -64,10 +62,9 @@ These options can be found in the *Privacy & Security* settings page ( :material
 
 ##### Sanitize on Close
 
-- Select **Delete cookies and site data when Firefox is closed**
+If you want to stay logged in to particular sites, you can allow exceptions in **Cookies and Site Data** → **Manage Exceptions...**
 
-!!! note
-    You can still stay logged into websites by allowing exceptions (**Cookies and Site Data** → **Manage Exceptions...**)
+- Select **Delete cookies and site data when Firefox is closed**
 
 ##### Disable Search Suggestions
 
@@ -75,8 +72,7 @@ These options can be found in the *Privacy & Security* settings page ( :material
 - Clear **Suggestions from sponsors**
 - Clear **Improve the Firefox Suggest experience**
 
-!!! note
-    Search suggestion features may not be available in your region.
+Search suggestion features may not be available in your region.
 
 ##### Disable Telemetry
 
@@ -249,8 +245,6 @@ There is also [AdGuard for iOS](https://adguard.com/en/adguard-ios/overview.html
 
     [Visit tosdr.org](https://tosdr.org){ .md-button .md-button--primary } [Privacy Policy](https://addons.mozilla.org/firefox/addon/terms-of-service-didnt-read/privacy){ .md-button }
 
-!!! note
-
-    We do not recommend installing ToS;DR as a browser extension. The same information is provided on their website.
+We do not recommend installing ToS;DR as a browser extension. The same information is provided on their website.
 
 --8<-- "includes/abbreviations.en.md"

--- a/docs/cloud.en.md
+++ b/docs/cloud.en.md
@@ -68,6 +68,11 @@ When using a web client, you are placing trust in the server to send you proper 
 
 ### Tahoe-LAFS
 
+!!! note
+
+    Due to the complexity of the system and the amount of nodes needed to set it up, Tahoe-LAFS is only recommended for seasoned system administrators.
+
+
 !!! recommendation
 
     ![Tahoe-LAFS logo](./assets/img/cloud/tahoe-lafs.svg#only-light){ align=right }
@@ -84,9 +89,5 @@ When using a web client, you are placing trust in the server to send you proper 
         - [:fontawesome-brands-linux: Linux](https://github.com/tahoe-lafs/tahoe-lafs#using-os-packages)
         - [:pg-netbsd: NetBSD](https://pkgsrc.se/filesystems/tahoe-lafs)
         - [:fontawesome-brands-git: Source](https://www.tahoe-lafs.org/trac/tahoe-lafs/browser)
-
-!!! note
-
-    Due to the complexity of the system and the amount of nodes needed to set it up, Tahoe-LAFS is only recommended for seasoned system administrators.
 
 --8<-- "includes/abbreviations.en.md"

--- a/docs/dns.en.md
+++ b/docs/dns.en.md
@@ -116,12 +116,12 @@ Encrypted DNS proxy software provides a local proxy for the [unencrypted DNS](te
 
     **dnscrypt-proxy** is a DNS proxy with support for [DNSCrypt](technology/dns.md#dnscrypt), [DNS-over-HTTPS](technology/dns.md#dns-over-https-doh), and [Anonymized DNS](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Anonymized-DNS).
 
+    !!! warning "The anonymized DNS feature does [**not**](technology/dns.md#why-shouldnt-i-use-encrypted-dns) anonymize other network traffic."
+
     [Visit github.com](https://github.com/DNSCrypt/dnscrypt-proxy/wiki){ .md-button .md-button--primary } [Privacy Policy](https://www.libreoffice.org/about-us/privacy/privacy-policy-en/){ .md-button }
 
     ??? downloads
 
         - [:fontawesome-brands-github: Source](https://github.com/DNSCrypt/dnscrypt-proxy)
-
-!!! warning "The anonymized DNS feature does [**not**](technology/dns.md#why-shouldnt-i-use-encrypted-dns) anonymize other network traffic."
 
 --8<-- "includes/abbreviations.en.md"

--- a/docs/email-clients.en.md
+++ b/docs/email-clients.en.md
@@ -5,11 +5,12 @@ icon: material/email-open
 Our recommendation list contains email clients that support both [OpenPGP](encryption.md#openpgp) and strong authentication such as [Open Authorization (OAuth)](https://en.wikipedia.org/wiki/OAuth). OAuth allows you to use [Multi-Factor Authentication](multi-factor-authentication) and prevent account theft.
 
 ??? Attention "Email does not provide forward secrecy"
+
     When using end-to-end encryption (E2EE) technology like [OpenPGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy), email will still have [some metadata](email.md#email-metadata-overview) that is not encrypted in the header of the email.
 
     OpenPGP also does not support [forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy), which means if either your or the recipient's private key is ever stolen, all previous messages encrypted with it will be exposed: [How do I protect my private keys?](email.md#email-encryption-overview). Consider using a medium that provides forward secrecy:
 
-    [Real-time Communication](real-time-communication.md){ .md-button .md-button--primary }
+    [Real-time Communication](real-time-communication.md){ .md-button }
 
 ### Thunderbird
 
@@ -31,6 +32,10 @@ Our recommendation list contains email clients that support both [OpenPGP](encry
 
 ### Apple Mail
 
+!!! note
+
+    For iOS devices we suggest [Canary Mail](#canary-mail) as it has PGP support which means you can send end-to-end encrypted email.
+
 !!! recommendation
 
     ![Apple Mail logo](assets/img/email-clients/applemail.png){ align=right }
@@ -38,10 +43,6 @@ Our recommendation list contains email clients that support both [OpenPGP](encry
     **Apple Mail** is included in macOS and can be extended to have OpenPGP support with [GPG Suite](encryption/#gpg-suite), which adds the ability to send encrypted email.
 
     [Visit apple.com](https://support.apple.com/guide/mail/welcome/mac){ .md-button .md-button--primary } [Privacy Policy](https://www.apple.com/legal/privacy/en-ww/){ .md-button }
-
-!!! note
-
-    For iOS devices we suggest [Canary Mail](#canary-mail) as it has PGP support which means you can send end-to-end encrypted email.
 
 ### GNOME Evolution
 

--- a/docs/encryption.en.md
+++ b/docs/encryption.en.md
@@ -104,7 +104,7 @@ BitLocker is [only supported](https://support.microsoft.com/en-us/windows/turn-o
         powershell Get-WmiObject -Namespace "root/cimv2/security/microsofttpm" -Class WIN32_tpm | findstr "IsActivated IsEnabled IsOwned SpecVersion"
         ```
 
-    4. Access Windows 10 "Advanced Startup Options". (Press "reboot" while holding shift button). *Troubleshoot > Advanced Options > Command Prompt*
+    4. Access [Advanced Startup Options](https://support.microsoft.com/en-us/windows/advanced-startup-options-including-safe-mode-b90e7808-80b5-a291-d4b8-1a1af602b617). You need to reboot while pressing the F8 key before Windows starts and go into the *command prompt* in **Troubleshoot** → **Advanced Options** → **Command Prompt**.
 
     5. Login with your account that has admin privileges and type this to start encryption:
         ```
@@ -157,7 +157,7 @@ We recommend storing a local recovery key in a secure place as opposed to utiliz
     udisksctl unlock -b /dev/loop0
     ```
 
-!!! Warning "Remember to back up volume headers"
+!!! note "Remember to back up volume headers"
 
     We recommend you always [back up your LUKS headers](https://wiki.archlinux.org/title/Dm-crypt/Device_encryption#Backup_and_restore) in case of partial drive failure. This can be done with:
 
@@ -225,7 +225,7 @@ Tools with command-line interfaces are useful for intergrating [shell scripts](h
 
 When encrypting with PGP, the user has the option to configure different options in their `gpg.conf` file. We recommend staying with the standard options specified in the [GnuPG user FAQ](https://www.gnupg.org/faq/gnupg-faq.html#new_user_gpg_conf).
 
-??? tip "Use future defaults when generating a key"
+!!! tip "Use future defaults when generating a key"
 
     When [generating keys](https://www.gnupg.org/gph/en/manual/c14.html) we suggest using the `future-default` command as this will instruct GnuPG use modern cryptography such as [Curve25519](https://en.wikipedia.org/wiki/Curve25519#History) and [Ed25519](https://ed25519.cr.yp.to/):
 
@@ -268,6 +268,10 @@ When encrypting with PGP, the user has the option to configure different options
 
 ### GPG Suite
 
+!!! note
+
+    We suggest [Canary Mail](email-clients/#canary-mail) for using PGP with email on iOS devices.
+
 !!! recommendation
 
     ![GPG Suite logo](assets/img/encryption-software/gpgsuite.png){ align=right }
@@ -282,10 +286,6 @@ When encrypting with PGP, the user has the option to configure different options
 
         - [:fontawesome-brands-apple: macOS](https://gpgtools.org)
         - [:fontawesome-brands-git: Source](https://github.com/GPGTools)
-
-!!! note
-
-    We suggest [Canary Mail](email-clients/#canary-mail) for using PGP with email on iOS devices.
 
 ### OpenKeychain
 

--- a/docs/metadata-removal-tools.en.md
+++ b/docs/metadata-removal-tools.en.md
@@ -76,11 +76,13 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
         - [:pg-f-droid: F-Droid](https://f-droid.org/en/packages/de.kaffeemitkoffein.imagepipe/)
         - [:fontawesome-brands-git: Source](https://codeberg.org/Starfish/Imagepipe)
 
-!!! info
-
-    Imagepipe is only available from F-Droid and not in Google Play. If you're looking for a paint app in Google Play we suggest [Pocket Paint](https://play.google.com/store/apps/details?id=org.catrobat.paintroid).
+Imagepipe is only available from F-Droid and not in Google Play. If you're looking for a paint app in Google Play we suggest [Pocket Paint](https://play.google.com/store/apps/details?id=org.catrobat.paintroid).
 
 ### Metapho
+
+!!! attention
+
+    Metapho is closed source. We recommend it, due to the few choices there are for iOS devices.
 
 !!! recommendation
 
@@ -93,11 +95,6 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
     ??? downloads
 
         - [:fontawesome-brands-app-store-ios: App Store](https://apps.apple.com/us/app/metapho/id914457352)
-
-!!! attention
-
-    Metapho is closed source. We recommend it, due to the few choices there are for iOS devices.
-
 
 ## Command-line
 
@@ -122,7 +119,7 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
         - [:fontawesome-brands-github: Source](https://github.com/exiftool/exiftool)
 
 
-??? example "Deleting data from a directory of files"
+!!! example "Deleting data from a directory of files"
 
     ```bash
     exiftool -all= *.file_extension

--- a/docs/multi-factor-authentication.en.md
+++ b/docs/multi-factor-authentication.en.md
@@ -41,17 +41,17 @@ Nitrokey models can be configured using the [Nitrokey app](https://www.nitrokey.
 
 For the models which support HOTP and TOTP, there are 3 slots for HOTP and 15 for TOTP. Some Nitrokeys can act as a password manager. They can store 16 different credentials and encrypt them using the same password as the OpenPGP interface.
 
- The Nitrokey Pro 2, Nitrokey Storage 2, and the upcoming Nitrokey 3 supports system integrity verification for laptops with the [Coreboot](https://www.coreboot.org/) + [Heads](https://osresearch.net/) firmware. Purism's [Librem Key](https://puri.sm/products/librem-key/) is a rebranded NitroKey Pro 2 with similar firmware and can also be used for the same purposes.
-
- The Nitrokey has an open source firmware, unlike the YubiKey. The firmware on modern NitroKey models (except the **NitroKey Pro 2**) is updatable.
-
 !!! warning
 
     While Nitrokeys do not release the HOTP/TOTP secrets to the device they are plugged into, the HOTP and TOTP storage is **not** encrypted and is vulnerable to physical attacks.
 
-!!! attention
+!!! warning
 
     Resetting the OpenPGP interface on a Nitrokey will also make the password database [inaccessible](https://docs.nitrokey.com/pro/factory-reset.html).
+
+ The Nitrokey Pro 2, Nitrokey Storage 2, and the upcoming Nitrokey 3 supports system integrity verification for laptops with the [Coreboot](https://www.coreboot.org/) + [Heads](https://osresearch.net/) firmware. Purism's [Librem Key](https://puri.sm/products/librem-key/) is a rebranded NitroKey Pro 2 with similar firmware and can also be used for the same purposes.
+
+ The Nitrokey has an open source firmware, unlike the YubiKey. The firmware on modern NitroKey models (except the **NitroKey Pro 2**) is updatable.
 
 !!! tip
 

--- a/docs/notebooks.en.md
+++ b/docs/notebooks.en.md
@@ -31,9 +31,7 @@ If you are currently using an application like Evernote, Google Keep, or Microso
         - [:pg-f-droid: F-Droid](https://f-droid.org/en/packages/net.cozic.joplin)
         - [:fontawesome-brands-github: GitHub](https://github.com/laurent22/joplin)
 
-!!! warning
-
-    Joplin does not support password/pin protection for the [application itself or individual notes/notebooks](https://github.com/laurent22/joplin/issues/289). Data is still encrypted in transit and at the sync location using your master key.
+Joplin does not support password/pin protection for the [application itself or individual notes/notebooks](https://github.com/laurent22/joplin/issues/289). Data is still encrypted in transit and at the sync location using your master key.
 
 ### Standard Notes
 

--- a/docs/passwords.en.md
+++ b/docs/passwords.en.md
@@ -34,9 +34,7 @@ These password managers store the password database locally.
         - [:fontawesome-brands-chrome: Chrome](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
         - [:fontawesome-brands-github: Source](https://github.com/keepassxreboot/keepassxc)
 
-!!! warning
-
-    KeePassXC stores its export data as [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) files. This may mean data loss if you import this file into another password manager. We advise you check each record manually.
+KeePassXC stores its export data as [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) files. This may mean data loss if you import this file into another password manager. We advise you check each record manually.
 
 ### KeePassDX
 

--- a/docs/router.en.md
+++ b/docs/router.en.md
@@ -6,9 +6,6 @@ Below are a few alternative operating systems, that can be used on routers, Wi-F
 
 ### OpenWrt
 
-!!! note
-    Consult the [Table of Hardware](https://openwrt.org/toh/start) to check if your device is supported.
-
 !!! recommendation
 
     ![OpenWrt logo](assets/img/router/openwrt.svg#only-light){ align=right }
@@ -21,6 +18,8 @@ Below are a few alternative operating systems, that can be used on routers, Wi-F
     ??? downloads
 
         - [:fontawesome-brands-git: Source](https://git.openwrt.org)
+
+You can consult OpenWrt's [table of hardware](https://openwrt.org/toh/start) to check if your device is supported.
 
 ### pfSense
 

--- a/docs/search-engines.en.md
+++ b/docs/search-engines.en.md
@@ -20,9 +20,7 @@ Consider using a [VPN](vpn.md) or [Tor](https://www.torproject.org/) if your thr
 
     [Visit duckduckgo.com](https://duckduckgo.com){ .md-button .md-button--primary } [:pg-tor:](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion){ .md-button } [Privacy Policy](https://duckduckgo.com/privacy){ .md-button }
 
-!!! note
-
-    DuckDuckGo is based in the 🇺🇸 US. Their [Privacy Policy](https://duckduckgo.com/privacy) states they do log your search query, but not your IP or any other identifying information.
+DuckDuckGo is based in the :flag_us: US. Their [Privacy Policy](https://duckduckgo.com/privacy) states they **do** log your search query, but not your IP or any other identifying information.
 
 DuckDuckGo has a [lite](https://duckduckgo.com/lite) and [html](https://duckduckgo.com/html) only version, both of which [do not require JavaScript](https://help.duckduckgo.com/features/non-javascript) and can be used with their [Tor onion address](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion) (append [/lite](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/lite) or [/html](https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/html) for the respective version).
 
@@ -36,9 +34,7 @@ DuckDuckGo has a [lite](https://duckduckgo.com/lite) and [html](https://duckduck
 
     [Visit startpage.com](https://www.startpage.com){ .md-button .md-button--primary } [Privacy Policy](https://www.startpage.com/en/privacy-policy){ .md-button }
 
-!!! note
-
-    Startpage is based in the 🇳🇱 Netherlands. According to their [Privacy Policy](https://www.startpage.com/en/privacy-policy/), they only log details such as: operating system, type of browser and language. They do not log your IP address, search queries or other identifying information. Startpage proxies Google Search so Google does have access to your search queries.
+Startpage is based in the :flag_nl: Netherlands. According to their [Privacy Policy](https://www.startpage.com/en/privacy-policy/), they only log details such as: operating system, type of browser and language. They do not log your IP address, search queries or other identifying information. Startpage proxies Google Search so Google does have access to your search queries.
 
 Startpage's majority shareholder is System1 who is an adtech company. We don't think that is an issue as they have their own Privacy Policy. The Privacy Guides team reached out to Startpage [back in 2020](https://web.archive.org/web/20210118031008/https://blog.privacytools.io/relisting-startpage/) for clarification and was satisfied by the answers we received.
 
@@ -52,9 +48,7 @@ Startpage's majority shareholder is System1 who is an adtech company. We don't t
 
     [Visit mojeek.com](https://www.mojeek.com){ .md-button .md-button--primary } [Privacy Policy](https://www.mojeek.com/about/privacy){ .md-button }
 
-!!! note
-
-    The company is based in the 🇬🇧 UK. According to their [Privacy Policy](https://www.mojeek.com/about/privacy/), they log the originating country, time, page requested, and referral data of each query. IP addresses are not logged.
+The company is based in the :flag_gb: UK. According to their [Privacy Policy](https://www.mojeek.com/about/privacy/), they log the originating country, time, page requested, and referral data of each query. IP addresses are not logged.
 
 ### Searx
 

--- a/docs/setup/integrating-metadata-removal.en.md
+++ b/docs/setup/integrating-metadata-removal.en.md
@@ -7,8 +7,7 @@ When sharing files, it's important to remove associated metadata. Image files co
 
 While there are plenty of metadata removal tools, they typically aren't convenient to use. The guides featured here aim to detail how to integrate metadata removal tools in a simple fashion by utilizing easy-to-access system features.
 
-!!! tip "Related"
-    For a list of the metadata removal tools that we recommend, visit our [metadata removal tools](../metadata-removal-tools.md) page.
+- [Recommended metadata removal tools :material-arrow-right:](../metadata-removal-tools.md)
 
 ## macOS
 

--- a/docs/vpn.en.md
+++ b/docs/vpn.en.md
@@ -15,7 +15,7 @@ Find a no-logging VPN operator who isn’t out to sell or read your web traffic.
 
     [Download Tor](https://www.torproject.org/){ .md-button .md-button--primary } [Tor Myths & FAQ](https://medium.com/privacyguides/slicing-onions-part-1-myth-busting-tor-9ec188ae1904){ .md-button }
 
-??? info "When are VPNs useful?"
+??? question "When are VPNs useful?"
 
     If you're looking for additional **privacy** from your ISP, on a public Wi-Fi network, or while torrenting files, a VPN may be the solution for you as long as you understand the risks involved.
 
@@ -23,7 +23,7 @@ Find a no-logging VPN operator who isn’t out to sell or read your web traffic.
 
 ## Recommended Providers
 
-!!! example "Criteria"
+!!! summary "Criteria"
 
     Our recommended providers are outside the US, use encryption, accept Monero, support WireGuard & OpenVPN, and have a no logging policy. Read our [full list of criteria](#our-criteria) for more information.
 


### PR DESCRIPTION
We don't want to over-use them, because they should specifically call out important information. We have a number of (especially "notes" and "info") admonitions that could just as easily be plain-text, because their content isn't particularly more important than other content on the page.