### PR TITLE
Session messenger update

### DIFF
--- a/docs/real-time-communication.en.md
+++ b/docs/real-time-communication.en.md
@@ -112,7 +112,7 @@ Briar supports perfect forward secrecy by using the Bramble [Handshake](https://
 
 Session allows for E2EE in one-on-one chats or closed groups which allow for up to 100 members. Open groups have no restriction on the number of members, but are open by design.
 
-Session does [not](https://getsession.org/blog/session-protocol-technical-information) support perfect forward secrecy.
+Session does [not](https://getsession.org/blog/session-protocol-technical-information) support perfect forward secrecy, which is when an encryption system automatically and frequently changes the keys it uses to encrypt and decrypt information, such that if the latest key is compromised it exposes a smaller portion of sensitive information.
 
 Oxen requested an independent audit for Session in March of 2020. The audit [concluded](https://getsession.org/session-code-audit) in April of 2021, “The overall security level of this application is good and makes it usable for privacy-concerned people.”
 

--- a/docs/real-time-communication.en.md
+++ b/docs/real-time-communication.en.md
@@ -94,26 +94,29 @@ Briar supports perfect forward secrecy by using the Bramble [Handshake](https://
 
     ![Session logo](assets/img/messengers/session.svg){ align=right }
 
-    **Session** is an encrypted instant messenger that uses three random [service nodes](https://getsession.org/blog/onion-requests-session-new-message-routing-solution) to route messages anonymously on the [Oxen Network](https://oxen.io).
+    **Session** is a decentralized messenger with a focus on private, secure, and anonymous communications. Session offers support for direct messages, group chats, and voice calls.
+
+    Session utilizes the decentralized [Oxen Service Node Network](https://oxen.io/) to store and route messages. Every encrypted message is routed through three nodes in the Oxen Service Node Network, making it virtually impossible for the nodes to compile meaningful information about the users of the network.
 
     [Homepage](https://getsession.org/){ .md-button .md-button--primary }
 
     ??? downloads
 
-        - [:fontawesome-brands-windows: Windows](https://getsession.org/windows)
-        - [:fontawesome-brands-apple: macOS](https://getsession.org/mac)
+        - [:fontawesome-brands-windows: Windows](https://getsession.org/download)
+        - [:fontawesome-brands-apple: macOS](https://getsession.org/download)
         - [:fontawesome-brands-app-store-ios: App Store](https://apps.apple.com/app/id1470168868)
-        - [:fontawesome-brands-linux: Linux](https://www.getsession.org/linux)
-        - [:fontawesome-brands-android: Android](https://fdroid.getsession.org/)
+        - [:fontawesome-brands-linux: Linux](https://getsession.org/download)
         - [:fontawesome-brands-google-play: Google Play](https://play.google.com/store/apps/details?id=network.loki.messenger)
         - [:pg-f-droid: F-Droid](https://fdroid.getsession.org)
-        - [:fontawesome-brands-github: Source](https://github.com/oxen-io/session-desktop)
+        - [:fontawesome-brands-github: Source](https://github.com/oxen-io)
 
-Session allows for E2EE in one-to-one or closed rooms that allow up to 100 members. Open rooms have no restriction on the number of members, but anyone can join.
+Session allows for E2EE in one-on-one chats or closed groups which allow for up to 100 members. Open groups have no restriction on the number of members, but are open by design.
 
-Session does [not](https://getsession.org/blog/session-protocol-technical-information) support forward secrecy. The key pair for each conversation is not rotated.
+Session does [not](https://getsession.org/blog/session-protocol-technical-information) support forward secrecy.
 
-Session was independently audited in 2020. The protocol is described in a whitepaper.
+Oxen requested an independent audit for Session in March of 2020. The audit [concluded](https://getsession.org/session-code-audit) in April of 2021, “The overall security level of this application is good and makes it usable for privacy-concerned people.”
+
+Session has a [whitepaper](https://arxiv.org/pdf/2002.04609.pdf) describing the technicals of the app and protocol.
 
 ## Types of Communication Networks
 

--- a/docs/real-time-communication.en.md
+++ b/docs/real-time-communication.en.md
@@ -112,7 +112,7 @@ Briar supports perfect forward secrecy by using the Bramble [Handshake](https://
 
 Session allows for E2EE in one-on-one chats or closed groups which allow for up to 100 members. Open groups have no restriction on the number of members, but are open by design.
 
-Session does [not](https://getsession.org/blog/session-protocol-technical-information) support forward secrecy.
+Session does [not](https://getsession.org/blog/session-protocol-technical-information) support perfect forward secrecy.
 
 Oxen requested an independent audit for Session in March of 2020. The audit [concluded](https://getsession.org/session-code-audit) in April of 2021, “The overall security level of this application is good and makes it usable for privacy-concerned people.”
 

--- a/includes/abbreviations.en.md
+++ b/includes/abbreviations.en.md
@@ -46,7 +46,6 @@
 *[OTPs]: One-Time Passwords
 *[OpenPGP]: Open-source implementation of Pretty Good Privacy (PGP)
 *[P2P]: Peer-to-Peer
-*[PFS]: Perfect Forward Secrecy
 *[PGP]: Pretty Good Privacy (see OpenPGP)
 *[PII]: Personally Identifiable Information
 *[QNAME]: Qualified Name
@@ -74,4 +73,3 @@
 *[cgroups]: Control Groups
 *[fork]: In software development, a fork is created when developers take a copy of source code from one software package and start independent development on it, creating a distinct and separate piece of software.
 *[rolling release]: An update release cycle in which updates are released very frequently, instead of at set intervals.
-*[perfect forward secrecy]: When a piece of an encryption system automatically and frequently changes the keys it uses to encrypt and decrypt information, such that if the latest key is compromised, it exposes only a small portion of the user’s sensitive data.

--- a/includes/abbreviations.en.md
+++ b/includes/abbreviations.en.md
@@ -46,6 +46,7 @@
 *[OTPs]: One-Time Passwords
 *[OpenPGP]: Open-source implementation of Pretty Good Privacy (PGP)
 *[P2P]: Peer-to-Peer
+*[PFS]: Perfect Forward Secrecy
 *[PGP]: Pretty Good Privacy (see OpenPGP)
 *[PII]: Personally Identifiable Information
 *[QNAME]: Qualified Name
@@ -73,3 +74,4 @@
 *[cgroups]: Control Groups
 *[fork]: In software development, a fork is created when developers take a copy of source code from one software package and start independent development on it, creating a distinct and separate piece of software.
 *[rolling release]: An update release cycle in which updates are released very frequently, instead of at set intervals.
+*[perfect forward secrecy]: When a piece of an encryption system automatically and frequently changes the keys it uses to encrypt and decrypt information, such that if the latest key is compromised, it exposes only a small portion of the user’s sensitive data.


### PR DESCRIPTION
I was researching Session so I took the time to update the recommendation with some more polished info.

I replaced the download links with non-direct download links. I think linking to a direct download is a bad practice; visitors should ensure their download comes from the actual site, which is harder to determine with a direct link. I also removed the Android download link since it was a duplicate of the F-Droid link.