### PR TITLE
Enable SSH Git commit signing

### DIFF
--- a/.allowed_signers
+++ b/.allowed_signers
@@ -1,0 +1,1 @@
+jonah@privacyguides.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJUp+Gi8ZpTDDbZC+GY+3QnFfxkI9rAu07bceyoHDp9O


### PR DESCRIPTION
SSH commit signing is:

- Supported in Git
- Supported in Gitea, for example: https://code.privacyguides.dev/privacyguides/privacyguides.org/commit/7ed368c3eae2ebf5e9a0368724eda1ebbee29480
    <img width="1152" alt="CleanShot 2022-04-27 at 15 32 54@2x" src="https://user-images.githubusercontent.com/3637842/165626069-b1d9c8e3-dc85-4ba6-836c-3c136b64a1bc.png">

- Will be imminently supported in GitHub: https://github.com/github/feedback/discussions/7744#discussioncomment-2603637

In light of this third fact, I am switching my commit signatures to SSH. For now GitHub will display these as Unverified, but this will be fixed once GitHub updates their website.

<img width="1209" alt="CleanShot 2022-04-27 at 15 33 28@2x" src="https://user-images.githubusercontent.com/3637842/165626162-23a996ba-8b3a-452d-82b1-34d07abb3006.png">

To locally verify commits made to this repo, run this command (after this PR is merged):

```
git config gpg.ssh.allowedSignersFile .allowed_signers
```

Then you can:

```
$ git show --show-signature                             
commit 7ed368c3eae2ebf5e9a0368724eda1ebbee29480 (HEAD -> pr-ssh-signing, origin/pr-ssh-signing)
Good "git" signature for jonah@privacyguides.org with ED25519 key SHA256:oJSBSFgpWl4g+IwjL96Ya8ocGfI7r6VKnQw+257pZZ0
Author: Jonah Aragon <jonah@triplebit.net>
Date:   Wed Apr 27 15:25:31 2022 -0500
. . .
```

To sign commits with SSH yourself: https://calebhearth.com/sign-git-with-ssh