### PR TITLE
Link to Mastodon instead of Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 <div align="center">
   <a href="https://privacyguides.org#gh-light-mode-only">
     <img src="/docs/assets/img/layout/privacy-guides-logo.svg" width="500px" alt="Privacy Guides" />
@@ -15,6 +16,9 @@
 
   <p><a href="https://www.reddit.com/r/PrivacyGuides/">
     <img src="https://img.shields.io/reddit/subreddit-subscribers/PrivacyGuides?label=Subscribe%20to%20r%2FPrivacyGuides&style=social">
+  </a>
+  <a href="https://mastodon.social/@privacyguides">
+    <img src="https://img.shields.io/mastodon/follow/107604420394178246?style=social">
   </a>
   <a href="https://twitter.com/privacy_guides">
     <img src="https://img.shields.io/twitter/follow/privacy_guides?style=social">

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -38,9 +38,9 @@ It's important for a website like Privacy Guides to always stay up-to-date. We n
 <div class="grid cards" style="margin:auto;max-width:800px;text-align:center;" markdown>
 
 - [:fontawesome-brands-reddit: Join the r/PrivacyGuides Subreddit](https://www.reddit.com/r/privacyguides)
-- [:fontawesome-brands-twitter: Follow @Privacy_Guides on Twitter](https://twitter.com/privacy_guides)
+- [:fontawesome-brands-mastodon: Follow us on Mastodon](https://mastodon.social/@privacyguides)
 - [:material-book-edit: Contribute to this website](https://github.com/privacyguides/privacyguides.org)
-- [:material-chat: Chat with us on Matrix](https://matrix.to/#/#privacyguides:matrix.org)
+- [:pg-matrix: Chat with us on Matrix](https://matrix.to/#/#privacyguides:matrix.org)
 
 </div>
 <div style="padding:3em;text-align:center;" markdown>


### PR DESCRIPTION
Since we have Mastodon now, and it's somewhat mainstream as of late, it makes more sense to start promoting this primarily as our social media platform. We'll still keep Twitter in the README and website footer.