### PR TITLE
Fix redundant text in the Firefox card

### DIFF
--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -94,7 +94,7 @@ Search suggestions send everything you type in the address bar to the default se
 
 - [x] Select **Enable HTTPS-Only Mode in all windows**
 
-This prevents you from unintentionally connecting to a website in plain-text HTTP. The HTTP protocol is extremely uncommon nowadays, so this should have little to no impact on your day to day browsing.
+This prevents you from unintentionally connecting to a website in plain-text HTTP. HTTP is extremely uncommon nowadays, so this should have little to no impact on your day to day browsing.
 
 #### Sync
 

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -94,7 +94,7 @@ Search suggestions send everything you type in the address bar to the default se
 
 - [x] Select **Enable HTTPS-Only Mode in all windows**
 
-This prevents you from unintentionally connecting to a website in plain-text HTTP. HTTP is extremely uncommon nowadays, so this should have little to no impact on your day to day browsing.
+This prevents you from unintentionally connecting to a website in plain-text HTTP. Sites without HTTPS are uncommon nowadays, so this should have little to no impact on your day to day browsing.
 
 #### Sync
 


### PR DESCRIPTION
<!-- Please use a descriptive title for your PR, it will be included in our changelog -->

"The HTTP protocol" is redundant.