### PR TITLE
Remove type column from dns table

### DIFF
--- a/docs/dns.en.md
+++ b/docs/dns.en.md
@@ -11,14 +11,14 @@ icon: material/dns
 
 ## Recommended Providers
 
-| DNS Provider | Privacy Policy | Type | Protocols | Logging | ECS | Filtering |
-| ------------ | -------------- | ---- | --------- | ------- | --- | --------- |
-| [**AdGuard**](https://adguard.com/en/adguard-dns/overview.html) | [:octicons-link-external-24:](https://adguard.com/en/privacy/dns.html) | Commercial | Cleartext <br> DoH <br> DoT <br> DNSCrypt | Some[^1] | No | Based on server choice. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/AdguardTeam/AdGuardDNS)
-| [**Cloudflare**](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/) | [:octicons-link-external-24:](https://developers.cloudflare.com/1.1.1.1/privacy/public-dns-resolver/) | Commercial | Cleartext <br> DoH <br> DoT | Some[^2] | No | Based on server choice.|
-| [**ControlD**](https://controld.com) | [:octicons-link-external-24:](https://controld.com/privacy) | Commercial | Cleartext <br> DoH <br> DoT | Optional[^3] | No |  Based on server choice.  |
-| [**MullvadDNS**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls) | [:octicons-link-external-24:](https://mullvad.net/en/help/no-logging-data-policy/) | Commercial | DoH <br> DoT | No[^4] | No | Based on server choice. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/mullvad/dns-adblock)
-| [**NextDNS**](https://www.nextdns.io) | [:octicons-link-external-24:](https://www.nextdns.io/privacy) | Commercial | Cleartext <br> DoH <br> DoT <br> DNSCrypt | Optional[^5] | Optional | Based on server choice. |
-| [**Quad9**](https://quad9.net) | [:octicons-link-external-24:](https://quad9.net/privacy/policy/) | Non-Profit | Cleartext <br> DoH <br> DoT <br> DNSCrypt | Some[^6] | Optional |  Based on server choice, Malware blocking by default. |
+| DNS Provider | Privacy Policy | Protocols | Logging | ECS | Filtering |
+| ------------ | -------------- | --------- | ------- | --- | --------- |
+| [**AdGuard**](https://adguard.com/en/adguard-dns/overview.html) | [:octicons-link-external-24:](https://adguard.com/en/privacy/dns.html) | Cleartext <br> DoH <br> DoT <br> DNSCrypt | Some[^1] | No | Based on server choice. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/AdguardTeam/AdGuardDNS)
+| [**Cloudflare**](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/) | [:octicons-link-external-24:](https://developers.cloudflare.com/1.1.1.1/privacy/public-dns-resolver/) | Cleartext <br> DoH <br> DoT | Some[^2] | No | Based on server choice.|
+| [**ControlD**](https://controld.com) | [:octicons-link-external-24:](https://controld.com/privacy) | Cleartext <br> DoH <br> DoT | Optional[^3] | No |  Based on server choice.  |
+| [**MullvadDNS**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls) | [:octicons-link-external-24:](https://mullvad.net/en/help/no-logging-data-policy/) | DoH <br> DoT | No[^4] | No | Based on server choice. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/mullvad/dns-adblock)
+| [**NextDNS**](https://www.nextdns.io) | [:octicons-link-external-24:](https://www.nextdns.io/privacy) | Cleartext <br> DoH <br> DoT <br> DNSCrypt | Optional[^5] | Optional | Based on server choice. |
+| [**Quad9**](https://quad9.net) | [:octicons-link-external-24:](https://quad9.net/privacy/policy/) | Cleartext <br> DoH <br> DoT <br> DNSCrypt | Some[^6] | Optional |  Based on server choice, Malware blocking by default. |
 
 [^1]: AdGuard stores aggregated performance metrics of their DNS servers, namely the number of complete requests to a particular server, the number of blocked requests, and the speed of processing requests. They also keep and store the database of domains requested in within last 24 hours. "We need this information to identify and block new trackers and threats." "We also log how many times this or that tracker has been blocked. We need this information to remove outdated rules from our filters." [https://adguard.com/en/privacy/dns.html](https://adguard.com/en/privacy/dns.html)
 [^2]: Cloudflare collects and stores only the limited DNS query data that is sent to the 1.1.1.1 resolver. The 1.1.1.1 resolver service does not log personal data, and the bulk of the limited non-personally identifiable query data is stored only for 25 hours. [https://developers.cloudflare.com/1.1.1.1/privacy/public-dns-resolver/](https://developers.cloudflare.com/1.1.1.1/privacy/public-dns-resolver/)


### PR DESCRIPTION
<!-- Please use a descriptive title for your PR, it will be included in our changelog -->
The "Type" column in the DNS providers table is unnecessary as whether a provider is commercial or not is irrelevant; the only thing that matters in terms of how they'll treat your data is their privacy policy. Also removing a column should help the table feel less squished.
Resolves: #1208<!-- Did you solve an open GitHub issue? Put the number here so we mark it complete! -->

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
