### PR TITLE
Detail Safari Private Browsing

### DIFF
--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -191,14 +191,6 @@ Safari's Private Browsing mode offers additional privacy protections. Private Br
 
 Do note that Private Browsing does not save cookies and website data, so it won't be possible to remain signed into sites. This may be an inconvenience.
 
-###### macOS
-
-Open Safari preferences and view the General tab.
-
-- [x] Select **Safari opens with: A new private window**
-
-###### iOS
-
 Open Safari and tap the Tabs button, located in the bottom right. Then, open the Tab Groups list.
 
 - [x] Select **Private**

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -187,7 +187,19 @@ If you do not use Apple Pay, you can toggle off the ability for websites to chec
 
 ##### Always-on Private Browsing
 
-Open Safari and press the tabs icon in the bottom right corner. Open Tab Groups, located in the bottom middle.
+Safari's Private Browsing mode offers additional privacy protections. Private Browsing uses a new [ephemeral](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410529-ephemeral) session for each tab, meaning tabs are isolated from one another. There are also other smaller privacy benefits with Private Browsing, such as not sending a webpage’s address to Apple when using Safari's translation feature.
+
+Do note that Private Browsing does not save cookies and website data, so it won't be possible to remain signed into sites. This may be an inconvenience.
+
+###### macOS
+
+Open Safari preferences and view the General tab.
+
+- [x] Select **Safari opens with: A new private window**
+
+###### iOS
+
+Open Safari and tap the Tabs button, located in the bottom right. Then, open the Tab Groups list.
 
 - [x] Select **Private**
 

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -187,7 +187,7 @@ If you do not use Apple Pay, you can toggle off the ability for websites to chec
 
 ##### Always-on Private Browsing
 
-Open Safari and tap the Tabs button, located in the bottom right. Then, open the Tab Groups list.
+Open Safari and tap the Tabs button, located in the bottom right. Then, expand the Tab Groups list.
 
 - [x] Select **Private**
 

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -187,13 +187,13 @@ If you do not use Apple Pay, you can toggle off the ability for websites to chec
 
 ##### Always-on Private Browsing
 
-Safari's Private Browsing mode offers additional privacy protections. Private Browsing uses a new [ephemeral](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410529-ephemeral) session for each tab, meaning tabs are isolated from one another. There are also other smaller privacy benefits with Private Browsing, such as not sending a webpage’s address to Apple when using Safari's translation feature.
-
-Do note that Private Browsing does not save cookies and website data, so it won't be possible to remain signed into sites. This may be an inconvenience.
-
 Open Safari and tap the Tabs button, located in the bottom right. Then, open the Tab Groups list.
 
 - [x] Select **Private**
+
+Safari's Private Browsing mode offers additional privacy protections. Private Browsing uses a new [ephemeral](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410529-ephemeral) session for each tab, meaning tabs are isolated from one another. There are also other smaller privacy benefits with Private Browsing, such as not sending a webpage’s address to Apple when using Safari's translation feature.
+
+Do note that Private Browsing does not save cookies and website data, so it won't be possible to remain signed into sites. This may be an inconvenience.
 
 ##### iCloud Sync
 


### PR DESCRIPTION
Detail some of the benefits of Safari Private Browsing, added macOS instructions, and refined the iOS instructions based on [Apple's instructions](https://support.apple.com/en-us/HT203036).