### PR TITLE
Maintain aspect ratio of YouTube embeds

### DIFF
--- a/docs/linux-desktop/overview.en.md
+++ b/docs/linux-desktop/overview.en.md
@@ -27,14 +27,15 @@ We highly recommend that you choose distributions which stay close to the stable
 For frozen distributions, package maintainers are expected to backport patches to fix vulnerabilities (Debian is one such [example](https://www.debian.org/security/faq#handling)) rather than bump the software to the “next version” released by the upstream developer. Some security fixes [do not](https://arxiv.org/abs/2105.14565) receive a [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) (particularly less popular software) at all and therefore do not make it into the distribution with this patching model. As a result minor security fixes are sometimes held back until the next major release.
 
 We don’t believe holding packages back and applying interim patches is a good idea, as it diverges from the way the developer might have intended the software to work. [Richard Brown](https://rootco.de/aboutme/) has a presentation about this:
-
-<iframe width="100%" style="height:50vh"
-  src="https://www.youtube-nocookie.com/embed/i8c0mg_mS7U"
-  title="Regular Releases are Wrong, Roll for your life"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen>
-</iframe>
+<div class="yt-embed">
+  <iframe"
+    src="https://www.youtube-nocookie.com/embed/i8c0mg_mS7U"
+    title="Regular Releases are Wrong, Roll for your life"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen>
+  </iframe>
+</div>
 
 ## Traditional vs Atomic updates
 
@@ -46,13 +47,15 @@ A transactional update system creates a snapshot that is made before and after a
 
 The Atomic update method is used for immutable distributions like Silverblue, Tumbleweed, and NixOS and can achieve reliability with this model. [Adam Šamalík](https://twitter.com/adsamalik) provided a presentation on how `rpm-ostree` works with Silverblue:
 
-<iframe width="100%" style="height:50vh"
-  src="https://www.youtube-nocookie.com/embed/-hpV5l-gJnQ"
-  title="Let's try Fedora Silverblue — an immutable desktop OS! - Adam Šamalik"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen>
-</iframe>
+<div class="yt-embed">
+  <iframe"
+    src="https://www.youtube-nocookie.com/embed/-hpV5l-gJnQ"
+    title="Let's try Fedora Silverblue — an immutable desktop OS! - Adam Šamalik"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen>
+  </iframe>
+</div>
 
 ## “Security-focused” distributions
 

--- a/docs/linux-desktop/overview.en.md
+++ b/docs/linux-desktop/overview.en.md
@@ -27,8 +27,9 @@ We highly recommend that you choose distributions which stay close to the stable
 For frozen distributions, package maintainers are expected to backport patches to fix vulnerabilities (Debian is one such [example](https://www.debian.org/security/faq#handling)) rather than bump the software to the “next version” released by the upstream developer. Some security fixes [do not](https://arxiv.org/abs/2105.14565) receive a [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) (particularly less popular software) at all and therefore do not make it into the distribution with this patching model. As a result minor security fixes are sometimes held back until the next major release.
 
 We don’t believe holding packages back and applying interim patches is a good idea, as it diverges from the way the developer might have intended the software to work. [Richard Brown](https://rootco.de/aboutme/) has a presentation about this:
+
 <div class="yt-embed">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/i8c0mg_mS7U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/i8c0mg_mS7U" title="Regular Releases are Wrong, Roll for your life" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Traditional vs Atomic updates
@@ -42,7 +43,7 @@ A transactional update system creates a snapshot that is made before and after a
 The Atomic update method is used for immutable distributions like Silverblue, Tumbleweed, and NixOS and can achieve reliability with this model. [Adam Šamalík](https://twitter.com/adsamalik) provided a presentation on how `rpm-ostree` works with Silverblue:
 
 <div class="yt-embed">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/-hpV5l-gJnQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/-hpV5l-gJnQ" title="Let's try Fedora Silverblue — an immutable desktop OS! - Adam Šamalik" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## “Security-focused” distributions

--- a/docs/linux-desktop/overview.en.md
+++ b/docs/linux-desktop/overview.en.md
@@ -28,13 +28,7 @@ For frozen distributions, package maintainers are expected to backport patches t
 
 We don’t believe holding packages back and applying interim patches is a good idea, as it diverges from the way the developer might have intended the software to work. [Richard Brown](https://rootco.de/aboutme/) has a presentation about this:
 <div class="yt-embed">
-  <iframe"
-    src="https://www.youtube-nocookie.com/embed/i8c0mg_mS7U"
-    title="Regular Releases are Wrong, Roll for your life"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen>
-  </iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/i8c0mg_mS7U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Traditional vs Atomic updates
@@ -48,13 +42,7 @@ A transactional update system creates a snapshot that is made before and after a
 The Atomic update method is used for immutable distributions like Silverblue, Tumbleweed, and NixOS and can achieve reliability with this model. [Adam Šamalík](https://twitter.com/adsamalik) provided a presentation on how `rpm-ostree` works with Silverblue:
 
 <div class="yt-embed">
-  <iframe"
-    src="https://www.youtube-nocookie.com/embed/-hpV5l-gJnQ"
-    title="Let's try Fedora Silverblue — an immutable desktop OS! - Adam Šamalik"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen>
-  </iframe>
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/-hpV5l-gJnQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## “Security-focused” distributions

--- a/docs/security/multi-factor-authentication.en.md
+++ b/docs/security/multi-factor-authentication.en.md
@@ -76,13 +76,9 @@ When you create an account the public key is sent to the service, then when you 
 
 This presentation discusses the history of password authentication, the pitfalls (such as password reuse), and discussion of FIDO2 and [WebAuthn](https://webauthn.guide) standards.
 
-<iframe width="100%" style="height:50vh"
-  src="https://www.youtube-nocookie.com/embed/aMo4ZlWznao"
-  title="How FIDO2 and WebAuthn Stop Account Takeovers"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen>
-</iframe>
+<div class="yt-embed">
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/aMo4ZlWznao" title="How FIDO2 and WebAuthn Stop Account Takeovers" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 FIDO2 and WebAuthn have superior security and privacy properties when compared to any MFA methods.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -155,3 +155,19 @@ h1, h2, h3, .md-header__topic {
 .no-js .md-sidebar {
     align-self: auto;
 }
+
+/* Maintain 16:9 aspect ratio on embedded YT videos */
+.yt-embed {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%; 
+    height: 0;
+}
+
+.yt-embed iframe {
+    position: absolute;
+    top:0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
Resolves the issue where the embeds become visually glitchy when resizing the window. It now maintains a 16:9 aspect ratio

follow up to #1230