### PR TITLE
Add "learn more" links to subsections

### DIFF
--- a/docs/tools.en.md
+++ b/docs/tools.en.md
@@ -23,6 +23,8 @@ For your convenience, everything we recommend is listed below with a link to the
 
 </div>
 
+[Learn more :material-arrow-right:](browsers.md)
+
 **Additional Resources:**
 
 <div class="grid cards annotate" markdown>
@@ -38,7 +40,7 @@ For your convenience, everything we recommend is listed below with a link to the
 2. We do not recommend installing ToS;DR as a browser extension. The same information is provided on their website.
 
 
-[Learn more :material-arrow-right:](browsers.md)
+[Learn more :material-arrow-right:](browsers.md#additional-resources)
 
 ## Operating Systems
 
@@ -51,6 +53,8 @@ For your convenience, everything we recommend is listed below with a link to the
 - ![DivestOS logo](assets/img/android/divestos.svg){ .twemoji } [DivestOS](https://divestos.org/)
 
 </div>
+
+[Learn more :material-arrow-right:](android.md)
 
 **Android Apps:**
 
@@ -66,7 +70,7 @@ For your convenience, everything we recommend is listed below with a link to the
 
 </div>
 
-[Learn more :material-arrow-right:](android.md)
+[Learn more :material-arrow-right:](android.md#general-apps)
 
 ### Linux
 
@@ -132,6 +136,8 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 </div>
 
+[Learn more :material-arrow-right:](email.md)
+
 **Email Cloaking Services:**
 
 <div class="grid cards" markdown>
@@ -140,6 +146,8 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 - ![SimpleLogin logo](assets/img/email/mini/simplelogin.svg){ .twemoji } [SimpleLogin](https://simplelogin.io/)
 
 </div>
+
+[Learn more :material-arrow-right:](email.md#email-aliasing-services)
 
 **Self-Hosting Email:**
 
@@ -150,7 +158,7 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 </div>
 
-[Learn more :material-arrow-right:](email.md)
+[Learn more :material-arrow-right:](email.md#self-hosting-email)
 
 ### Search Engines
 
@@ -252,6 +260,8 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 - ![Tomb logo](assets/img/encryption-software/tomb.png){ .twemoji } [Tomb](https://www.dyne.org/software/tomb)
 
 </div>
+
+[Learn more :material-arrow-right:](encryption.md#openpgp)
 
 **OpenPGP Clients:**
 


### PR DESCRIPTION
I originally thought the Browser learn more link went missing since it's pushed down so far, so I took that as a sign that the links should probably be added for both the main and subsections.