### PR TITLE
Add warning to avoid third-party extensions on Brave

### DIFF
--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -131,10 +131,6 @@ The [Arkenfox project](https://github.com/arkenfox/user.js) provides a set of ca
 
     1. We advise against using the Flatpak version of Brave as it is believed to feature a weaker sandboxing system. As well, the package is **not** maintained by Brave Software, Inc.
 
-## Don't install uBlock Origin
-
-    You shouldn't use uBlock Origin addon on Brave Browser as it would be redundant with the **Shield** feature. Doing so would just increase your attack surface and would add mere impact of what the **Shield** feature can already bring you.
-
 #### Recommended Configuration
 
 Tor Browser is the only way to truly browse the internet anonymously. When you use Brave we recommend changing the following settings to protect your privacy from certain parties, but all browsers other than the [Tor Browser](#tor-browser) will be traceable by *somebody* in some regard or another.
@@ -187,6 +183,8 @@ Disable the extensions you do not use in **Extensions**
 - [ ] Uncheck **Hangouts**
 - [ ] Uncheck **Private window with Tor** (1)
 - [ ] Uncheck **WebTorrent**
+
+In addition, avoid installing third-party extensions.
 
 </div>
 

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -131,9 +131,9 @@ The [Arkenfox project](https://github.com/arkenfox/user.js) provides a set of ca
 
     1. We advise against using the Flatpak version of Brave as it is believed to feature a weaker sandboxing system. As well, the package is **not** maintained by Brave Software, Inc.
 
-!!! warning
+## Don't install uBlock Origin
 
-    You shouldn't use ublock Origin addon on Brave Browser as it would be redundant with the **Shield** feature. Doing so would just increase your attack surface and would add mere impact of what the **Shield** feature can already bring you.
+    You shouldn't use uBlock Origin addon on Brave Browser as it would be redundant with the **Shield** feature. Doing so would just increase your attack surface and would add mere impact of what the **Shield** feature can already bring you.
 
 #### Recommended Configuration
 

--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -131,6 +131,10 @@ The [Arkenfox project](https://github.com/arkenfox/user.js) provides a set of ca
 
     1. We advise against using the Flatpak version of Brave as it is believed to feature a weaker sandboxing system. As well, the package is **not** maintained by Brave Software, Inc.
 
+!!! warning
+
+    You shouldn't use ublock Origin addon on Brave Browser as it would be redundant with the **Shield** feature. Doing so would just increase your attack surface and would add mere impact of what the **Shield** feature can already bring you.
+
 #### Recommended Configuration
 
 Tor Browser is the only way to truly browse the internet anonymously. When you use Brave we recommend changing the following settings to protect your privacy from certain parties, but all browsers other than the [Tor Browser](#tor-browser) will be traceable by *somebody* in some regard or another.


### PR DESCRIPTION
I think adding UBO on Brave is close to useless because it would be redundant with **Shield** feature of the browser.

I'm not sure about my syntax of my sentences though as english isn't my native language.
Please reconsider my grammar, vocabulary and the syntax if you'll agree to merge this.