### PR TITLE
Change snowflake extension to snowflake site

### DIFF
--- a/docs/browsers.en.md
+++ b/docs/browsers.en.md
@@ -361,13 +361,15 @@ There is also [AdGuard for iOS](https://adguard.com/en/adguard-ios/overview.html
     ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ align=right }
     ![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ align=right }
 
-    **Snowflake** is a browser extension which allows you to donate bandwidth to the Tor Project by operating a "Snowflake proxy" within your browser. People who are censored can use Snowflake proxies to connect to the Tor network. Installing this extension is a great way to contribute to the network even if you don't have the technical know-how to run a Tor relay or bridge.
+    **Snowflake** allows you to donate bandwidth to the Tor Project by operating a "Snowflake proxy" within your browser. People who are censored can use Snowflake proxies to connect to the Tor network. Snowflake is a great way to contribute to the network even if you don't have the technical know-how to run a Tor relay or bridge.
 
-    [Website](https://snowflake.torproject.org/){ .md-button .md-button--primary }
+    [Website](https://snowflake.torproject.org/embed.html){ .md-button .md-button--primary }
 
-The Snowflake browser extension does not increase your privacy in any way, nor is it used to connect to the Tor network within your personal browser. However, if your internet connection is uncensored, you should consider running it to help people in censored networks achieve better privacy themselves. There is no need to worry about which websites people are accessing through your proxy. Their visible browsing IP address will match their Tor exit node, not yours.
+Snowflake does not increase your privacy in any way, nor is it used to connect to the Tor network within your personal browser. However, if your internet connection is uncensored, you should consider running it to help people in censored networks achieve better privacy themselves. There is no need to worry about which websites people are accessing through your proxy. Their visible browsing IP address will match their Tor exit node, not yours.
 
 Running a Snowflake proxy is low-risk, even moreso than running a Tor relay or bridge which are already not particularly risky endeavours. However, it does still proxy traffic through your network which can be impactful in some ways, especially if your network is bandwidth-limited. Make sure you understand [how Snowflake works](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/wikis/home) before deciding whether to run a proxy.
+
+We do not recomment installing Snowflake as a browser extension as extensions increase your browser's [attack surface](https://en.wikipedia.org/wiki/Attack_surface).
 
 ### Terms of Service; Didn't Read
 


### PR DESCRIPTION
<!-- Please use a descriptive title for your PR, it will be included in our changelog -->
Snowflake can now be used in a [browser tab](https://snowflake.torproject.org/embed.html) instead of an extension, so updated the site to reflect this.

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
