### PR TITLE
Improve README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <!-- markdownlint-disable MD041 -->
 <div align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/100533118/169622905-58b29d79-afde-4e60-b35a-2e308246beee.svg">
-    <img alt="Privacy Guides" width="500px" src="https://user-images.githubusercontent.com/100533118/169622923-38edf4b3-1960-48ab-b440-63cc149f1bec.svg">
-  </picture>
+  <a href="https://www.privacyguides.org/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/100533118/169622905-58b29d79-afde-4e60-b35a-2e308246beee.svg">
+      <img alt="Privacy Guides" width="500px" src="https://user-images.githubusercontent.com/100533118/169622923-38edf4b3-1960-48ab-b440-63cc149f1bec.svg">
+    </picture>
+  </a>
 
   <p><em>Your central privacy and security resource to protect yourself online.</em></p>
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <div align="center">
   <a href="https://www.privacyguides.org/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/100533118/169622905-58b29d79-afde-4e60-b35a-2e308246beee.svg">
-      <img alt="Privacy Guides" width="500px" src="https://user-images.githubusercontent.com/100533118/169622923-38edf4b3-1960-48ab-b440-63cc149f1bec.svg">
+      <source media="(prefers-color-scheme: dark)" srcset="https://privacyguides.org/assets/img/layout/privacy-guides-logo-dark.svg">
+      <img alt="Privacy Guides" width="500px" src="https://privacyguides.org/assets/img/layout/privacy-guides-logo.svg">
     </picture>
   </a>
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 <!-- markdownlint-disable MD041 -->
 <div align="center">
-  <a href="https://privacyguides.org#gh-light-mode-only">
-    <img src="/docs/assets/img/layout/privacy-guides-logo.svg" width="500px" alt="Privacy Guides" />
-  </a>
-  
-  <a href="https://privacyguides.org#gh-dark-mode-only">
-    <img src="/docs/assets/img/layout/privacy-guides-logo-dark.svg" width="500px" alt="Privacy Guides" />
-  </a>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/100533118/169622659-ce80b179-bfbc-457c-b0f8-214300917439.svg">
+    <img alt="Privacy Guides" width="500px" src="https://user-images.githubusercontent.com/100533118/169622707-191404fb-4355-4305-bf65-5c81ae2ed7f5.svg">
+  </picture>
 
   <p><em>Your central privacy and security resource to protect yourself online.</em></p>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- markdownlint-disable MD041 -->
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/100533118/169622659-ce80b179-bfbc-457c-b0f8-214300917439.svg">
-    <img alt="Privacy Guides" width="500px" src="https://user-images.githubusercontent.com/100533118/169622707-191404fb-4355-4305-bf65-5c81ae2ed7f5.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/100533118/169622905-58b29d79-afde-4e60-b35a-2e308246beee.svg">
+    <img alt="Privacy Guides" width="500px" src="https://user-images.githubusercontent.com/100533118/169622923-38edf4b3-1960-48ab-b440-63cc149f1bec.svg">
   </picture>
 
   <p><em>Your central privacy and security resource to protect yourself online.</em></p>


### PR DESCRIPTION
I've updated the README images to make use of the new theme context syntax released yesterday (https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/)

*also: https://github.com/privacyguides/.github/pull/4*

> **Note**
> This has two benefits:
> 1. No longer includes `#gh-light/dark-mode-only` in the linked URL
> 2. Should fix the missing image issue on the git mirrors

(this note thing is new too lol, wanted to test it out)