### PR TITLE
Change the light switch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,13 +64,13 @@ theme:
       scheme: default
       accent: deep purple
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/toggle-switch-variant
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       accent: deep purple
       toggle:
-        icon: material/toggle-switch
+        icon: material/toggle-switch-variant-off
         name: Switch to light mode
 watch:
   - theme


### PR DESCRIPTION
matrix:
> the dark mode switch in the navbar lol, right now it's 'off' in light mode and 'on' in dark mode, so like the opposite of a regular light switch
> didn't notice it before, but when i did now it bothers me