### PR TITLE
Remove Handy News Reader

### DIFF
--- a/docs/news-aggregators.en.md
+++ b/docs/news-aggregators.en.md
@@ -70,22 +70,6 @@ A [news aggregator](https://en.wikipedia.org/wiki/News_aggregator) is a way to k
         - [:pg-f-droid: F-Droid](https://f-droid.org/en/packages/com.nononsenseapps.feeder/)
         - [:fontawesome-brands-gitlab: Source](https://gitlab.com/spacecowboy/Feeder)
 
-### Handy News Reader
-
-!!! recommendation
-
-    ![Handy News Reader logo](assets/img/news-aggregators/handy-news-reader.svg){ align=right }
-
-    **Handy News Reader** is a fork of [Flym](https://github.com/FredJul/Flym) that has many [features](https://github.com/yanus171/Handy-News-Reader#features) and works well with folders of RSS feeds. It supports [RSS](https://en.wikipedia.org/wiki/RSS), [Atom](https://en.wikipedia.org/wiki/Atom_(Web_standard)) and [RDF](https://en.wikipedia.org/wiki/RDF%2FXML).
-
-    [Homepage](https://yanus171.github.io/Handy-News-Reader/){ .md-button .md-button--primary }
-
-    ??? downloads
-
-        - [:fontawesome-brands-google-play: Google Play](https://play.google.com/store/apps/details?id=ru.yanus171.feedexfork)
-        - [:pg-f-droid: F-Droid](https://f-droid.org/en/packages/ru.yanus171.feedexfork/)
-        - [:fontawesome-brands-github: Source](https://github.com/yanus171/Handy-News-Reader)
-
 ### NetNewsWire
 
 !!! recommendation

--- a/docs/tools.en.md
+++ b/docs/tools.en.md
@@ -390,7 +390,6 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 - ![GNOME Feeds logo](assets/img/news-aggregators/gfeeds.svg){ .twemoji } [GNOME Feeds](news-aggregators.md#gnome-feeds)
 - ![Akregator logo](assets/img/news-aggregators/akregator.svg){ .twemoji } [Akregator](news-aggregators.md#akregator)
 - ![Feeder logo](assets/img/news-aggregators/feeder.png){ .twemoji} [Feeder](news-aggregators.md#feeder)
-- ![Handy News Reader logo](assets/img/news-aggregators/handy-news-reader.svg){ .twemoji } [Handy News Reader](news-aggregators.md#handy-news-reader)
 - ![NetNewsWire logo](assets/img/news-aggregators/netnewswire.png){ .twemoji } [NetNewsWire](news-aggregators.md#netnewswire)
 - ![Miniflux logo](assets/img/news-aggregators/miniflux.svg#only-light){ .twemoji }![Miniflux logo](assets/img/news-aggregators/miniflux-dark.svg#only-dark){ .twemoji } [Miniflux](news-aggregators.md#miniflux)
 - ![Newsboat logo](assets/img/news-aggregators/newsboat.svg){ .twemoji } [Newsboat](news-aggregators.md#newsboat)


### PR DESCRIPTION
Feeder seems to be better actively developed by the community, has CI set up, and support JSON feeds.

Now that it has features such as pinning, and folders, I don't see any real reason to use this.