### PR TITLE
Fixes for the Linux Page

### DIFF
--- a/docs/linux-desktop/hardening.en.md
+++ b/docs/linux-desktop/hardening.en.md
@@ -32,15 +32,17 @@ Do **not** disable unprivileged user namespaces if you use software that relies 
 
 ## Linux-Hardened
 
-Some distributions like Arch Linux have the [linux-hardened](https://github.com/anthraxx/linux-hardened), kernel package. It includes [hardening patches](https://wiki.archlinux.org/title/security#Kernel_hardening) and more security-conscious defaults. Linux-Hardened has `kernel.unprivileged_userns_clone=0` disabled by default. See the [warning above](#kernel-hardening) about how this might impact you.
+Some distributions like Arch Linux have the [linux-hardened](https://github.com/anthraxx/linux-hardened), kernel package. It includes [hardening patches](https://wiki.archlinux.org/title/security#Kernel_hardening) and more security-conscious defaults. Linux-Hardened has `kernel.unprivileged_userns_clone=0` disabled by default. See the [note above](#kernel-hardening) about how this might impact you.
 
 ## Linux Kernel Runtime Guard (LKRG)
 
-LKRG is a kernel module that performs runtime integrity check on the kernel to help detect detect exploits against the kernel. LKRG works in a *post*-detect fashion, meaning that it attempts to respond to unauthorized modifications to the running Linux kernel. The intention is that it will defeat many pre-existing exploits as well as undiscovered vulnerabilities. Some hardened distributions, such as [Kicksecure](https://www.kicksecure.com/wiki/Linux_Kernel_Runtime_Guard_LKRG), have documentation.
+LKRG is a kernel module that performs runtime integrity check on the kernel to help detect detect exploits against the kernel. LKRG works in a *post*-detect fashion, attempting to respond to unauthorized modifications to the running Linux kernel. While it is [bypassable by design](https://lkrg.org/), it does stop off-the-shelf malware that does not specifically target LKRG itself. This may make exploits harder to develop and execute on vulnerable systems.
+
+If you can get LKRG and maintain module updates it provides a worthwhile improvement to security. Debian based distributions can get the LKRG DKMS from KickSecure's secure repository and the [KickSecure documentation](https://www.kicksecure.com/wiki/Linux_Kernel_Runtime_Guard_LKRG) has instructions on how this can be achieved. There is no LKRG package for Fedora yet, however the Qubes OS project has a COPR repository which [may become]((https://github.com/QubesOS/qubes-issues/issues/5461) part of the main distribution in the future. Archlinux based systems provide LKRG DKMS modules via an [AUR package](https://aur.archlinux.org/packages/lkrg-dkms).
 
 ## GRSecurity
 
-GRSecurity is a set of kernel patches that attempt to improve security of the Linux kernel. Open source  access, however, requires [subscription to a paid model](https://grsecurity.net/passing_the_baton).
+GRSecurity is a set of kernel patches that attempt to improve security of the Linux kernel.  It requires [payment to access]((https://github.com/QubesOS/qubes-issues/issues/5461) the code.
 
 ## Simultaneous multithreading (SMT)
 
@@ -58,7 +60,9 @@ If you are not using openSUSE, consider changing the default [umask](https://en.
 
 ## Mountpoint hardening
 
-Consider adding the [following options](https://man7.org/linux/man-pages/man8/mount.8.html) `nodev`, `noexec`, and `nosuid` to [mountpoints](https://en.wikipedia.org/wiki/Mount_(computing)) which do not need them. Typically, these could be applied to `/boot`, `/boot/efi`, `/home`, `/root`, and `/var`.
+Consider adding the [following options](https://man7.org/linux/man-pages/man8/mount.8.html) `nodev`, `noexec`, and `nosuid` to [mountpoints](https://en.wikipedia.org/wiki/Mount_(computing)) which do not need them. Typically, these could be applied to `/boot`, `/boot/efi`, and `/var`.
+
+These flags could also be applied to `/home` and `/root` as well, however, `noexec` will prevent applications from working that require binary execution in those locations. This includes products such as Flatpak and Snap.
 
 If you use [Toolbox](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/), `/var/log/journal` must not have any of those options. If you are on Arch Linux, do not apply `noexec` to `/var/tmp`.
 


### PR DESCRIPTION
I don't like polarbears. 

On a serious note though, the without the last sentence, the GRSecurity part sounds weird. As for the LKRG kernel module, the point here is not that it is available on KickSecure, the point here is that if you use Debian you should just add the KickSecure repo and install it since it is fairly easy anyways. Same for Arch and possibly Fedora in the future.

I also updated the mountpoint hardening section since `noexec` on /home and /root breaks a lot of stuff.