### PR TITLE
Add WWDC22 post to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
   - 'Discussions': 'https://github.com/orgs/privacyguides/discussions'
   - 'Blog':
     - '2022':
+      - 'Everything Apple announced for Privacy at WWDC22': 'blog/2022/06/09/wwdc22-privacy.md'
       - '"Move Fast and Break Things"': 'blog/2022/04/04/move-fast-and-break-things.md'
     - '2021':
       - 'Firefox Privacy: 2021 Update': 'blog/2021/12/01/firefox-privacy-2021-update.md'


### PR DESCRIPTION
Prerequisite: https://github.com/privacyguides/blog/pull/3 to be merged