### PR TITLE
Reorder DivestOS and CalyxOS

### DIFF
--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -81,7 +81,7 @@ DivestOS implements some system hardening patches originally developed for Graph
 
 CalyxOS optionally includes [microG](https://microg.org/), a partially open source reimplementation of Play Services which provides broader app compatibility. It also bundles in alternate location services: [Mozilla](https://location.services.mozilla.com/) and [DejaVu](https://github.com/n76/DejaVu).
 
-CalyxOS [supports](https://calyxos.org/docs/guide/device-support/) Google Pixel phones, the OnePlus 8T/9 and the Fairphone 4 if you can't use DivestOS. 
+CalyxOS [supports](https://calyxos.org/docs/guide/device-support/) Google Pixel phones, the OnePlus 8T/9/9 Pro and the Fairphone 4. 
 
 ## Android Devices
 

--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -61,7 +61,7 @@ DivestOS implements some system hardening patches originally developed for Graph
 
 !!! warning
 
-    DivestOS firmware update [status](https://gitlab.com/divested-mobile/firmware-empty/-/blob/master/STATUS) and quality control varies across the devices it supports. We still recommend GrapheneOS or CalyxOS depending on your device's compatibility. For other devices, DivestOS is a good alternative.
+    DivestOS firmware update [status](https://gitlab.com/divested-mobile/firmware-empty/-/blob/master/STATUS) and quality control varies across the devices it supports. We still recommend GrapheneOS depending on your device's compatibility. For other devices, DivestOS is a good alternative.
 
     Not all of the supported devices have verified boot, and some perform it better than others.
     

--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -71,7 +71,9 @@ DivestOS implements some system hardening patches originally developed for Graph
 
     ![CalyxOS logo](assets/img/android/calyxos.svg){ align=right }
 
-    **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so verified boot is fully supported. We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4.
+    **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so verified boot is fully supported. 
+    
+    We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4.
 
     [:octicons-home-16: Homepage](https://calyxos.org/){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://calyxinstitute.org/legal/privacy-policy){ .card-link title="Privacy Policy" }

--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -73,7 +73,7 @@ DivestOS implements some system hardening patches originally developed for Graph
 
     **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so verified boot is fully supported. 
     
-    We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4.
+    We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4 if you need microG.
 
     [:octicons-home-16: Homepage](https://calyxos.org/){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://calyxinstitute.org/legal/privacy-policy){ .card-link title="Privacy Policy" }

--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -81,7 +81,7 @@ DivestOS implements some system hardening patches originally developed for Graph
 
 CalyxOS optionally includes [microG](https://microg.org/), a partially open source reimplementation of Play Services which provides broader app compatibility. It also bundles in alternate location services: [Mozilla](https://location.services.mozilla.com/) and [DejaVu](https://github.com/n76/DejaVu).
 
-CalyxOS [supports](https://calyxos.org/docs/guide/device-support/) Google Pixel phones, the OnePlus 8T/9 and the Fairphone 4. 
+CalyxOS [supports](https://calyxos.org/docs/guide/device-support/) Google Pixel phones, the OnePlus 8T/9 and the Fairphone 4 if you can't use DivestOS. 
 
 ## Android Devices
 

--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -37,24 +37,6 @@ GrapheneOS supports [Sandboxed Google Play](https://grapheneos.org/usage#sandbox
 
 Google Pixel phones are the only devices that currently meet GrapheneOS's [hardware security requirements](https://grapheneos.org/faq#device-support).
 
-### CalyxOS
-
-!!! recommendation
-
-    ![CalyxOS logo](assets/img/android/calyxos.svg){ align=right }
-
-    **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so verified boot is fully supported.
-
-    [:octicons-home-16: Homepage](https://calyxos.org/){ .md-button .md-button--primary }
-    [:octicons-eye-16:](https://calyxinstitute.org/legal/privacy-policy){ .card-link title="Privacy Policy" }
-    [:octicons-info-16:](https://calyxos.org/docs/){ .card-link title=Documentation}
-    [:octicons-code-16:](https://github.com/CalyxOS){ .card-link title="Source Code" }
-    [:octicons-heart-16:](https://members.calyxinstitute.org/donate){ .card-link title=Contribute }
-
-CalyxOS optionally includes [microG](https://microg.org/), a partially open source reimplementation of Play Services which provides broader app compatibility. It also bundles in alternate location services: [Mozilla](https://location.services.mozilla.com/) and [DejaVu](https://github.com/n76/DejaVu).
-
-CalyxOS [supports](https://calyxos.org/docs/guide/device-support/) Google Pixel phones, the OnePlus 8T/9 and the Fairphone 4. We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4.
-
 ### DivestOS
 
 !!! recommendation
@@ -82,6 +64,24 @@ DivestOS implements some system hardening patches originally developed for Graph
     DivestOS firmware update [status](https://gitlab.com/divested-mobile/firmware-empty/-/blob/master/STATUS) and quality control varies across the devices it supports. We still recommend GrapheneOS or CalyxOS depending on your device's compatibility. For other devices, DivestOS is a good alternative.
 
     Not all of the supported devices have verified boot, and some perform it better than others.
+    
+### CalyxOS
+
+!!! recommendation
+
+    ![CalyxOS logo](assets/img/android/calyxos.svg){ align=right }
+
+    **CalyxOS** is a system with some privacy features on top of AOSP, including [Datura](https://calyxos.org/docs/tech/datura-details) firewall, [Signal](https://signal.org) integration in the dialer app, and a built in panic button. CalyxOS also comes with firmware updates and signed builds, so verified boot is fully supported. We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4.
+
+    [:octicons-home-16: Homepage](https://calyxos.org/){ .md-button .md-button--primary }
+    [:octicons-eye-16:](https://calyxinstitute.org/legal/privacy-policy){ .card-link title="Privacy Policy" }
+    [:octicons-info-16:](https://calyxos.org/docs/){ .card-link title=Documentation}
+    [:octicons-code-16:](https://github.com/CalyxOS){ .card-link title="Source Code" }
+    [:octicons-heart-16:](https://members.calyxinstitute.org/donate){ .card-link title=Contribute }
+
+CalyxOS optionally includes [microG](https://microg.org/), a partially open source reimplementation of Play Services which provides broader app compatibility. It also bundles in alternate location services: [Mozilla](https://location.services.mozilla.com/) and [DejaVu](https://github.com/n76/DejaVu).
+
+CalyxOS [supports](https://calyxos.org/docs/guide/device-support/) Google Pixel phones, the OnePlus 8T/9 and the Fairphone 4. 
 
 ## Android Devices
 


### PR DESCRIPTION
I think CalyxOS should be only used for the OnePlus 8/9 and the FP4 for those who need Google Play Services.
Because if they don't, they should stick with DivestOS.
Moreover DivestOS is more hardened than CalyxOS.
That's why I think DivestOS should be recommended after GrapheneOS.

I also put this sentence :
> We only recommend CalyxOS as a harm reduction measure for the OnePlus 8T, OnePlus 9, and especially the Fairphone 4 if you need microG.

... in the box presentation (idk how you call that) of CalyxOS, bc I think it's important notice.