### PR TITLE
Removing email provider security section

### DIFF
--- a/docs/basics/email-security.en.md
+++ b/docs/basics/email-security.en.md
@@ -39,6 +39,4 @@ Email metadata is protected from outside observers with [Opportunistic TLS](http
 
 Email metadata is crucial to the most basic functionality of email (where it came from, and where it has to go). E2EE was not built into the email protocols originally, instead requiring add-on software like OpenPGP. Because OpenPGP messages still have to work with traditional email providers, it cannot encrypt email metadata, only the message body itself. That means that even when using OpenPGP, outside observers can see lots of information about your messages, such as who you're emailing, the subject lines, when you're emailing, etc.
 
-## Email provider security
-
 --8<-- "includes/abbreviations.en.md"


### PR DESCRIPTION
We could add one, but it was doing nothing as a standalone piece of text.


