### PR TITLE
Wording and remove parentheses in Android Overview

### DIFF
--- a/docs/android/overview.en.md
+++ b/docs/android/overview.en.md
@@ -48,7 +48,7 @@ It's important to not use an [end-of-life](https://endoflife.date/android) versi
 
 ## Android Permissions
 
-[Permissions on Android](https://developer.android.com/guide/topics/permissions/overview) grant you control over what apps are allowed to access. Google regularly makes [improvements](https://developer.android.com/about/versions/11/privacy/permissions) on the permission system in each successive version. All apps you install are strictly [sandboxed](https://source.android.com/security/app-sandbox), therefore, there is no need to install any antivirus apps. The savings you make from not purchasing or subscribing to security apps is better spent on paying for a supported device in the future.
+[Permissions on Android](https://developer.android.com/guide/topics/permissions/overview) grant you control over what apps are allowed to access. Google regularly makes [improvements](https://developer.android.com/about/versions/11/privacy/permissions) on the permission system in each successive version. All apps you install are strictly [sandboxed](https://source.android.com/security/app-sandbox), therefore, there is no need to install any antivirus apps. A smartphone with the latest version of Android will always be more secure than an old smartphone with an antivirus that you have paid for. It's better not to pay for antivirus software and to save money to buy a new smartphone such as a Google Pixel.
 
 Should you want to run an app that you're unsure about, consider using a user or work profile.
 
@@ -70,7 +70,7 @@ This method is generally less secure than a secondary user profile; however, it 
 
 ## VPN Killswitch
 
-Android 7 and above supports a VPN killswitch and it is available without the need to install third-party apps. This feature can prevent leaks if the VPN is disconnected. It can be found in (:gear: **Settings** → **Network & internet** → **VPN** → :gear: → **Block connections without VPN**).
+Android 7 and above supports a VPN killswitch and it is available without the need to install third-party apps. This feature can prevent leaks if the VPN is disconnected. It can be found in :gear: **Settings** → **Network & internet** → **VPN** → :gear: → **Block connections without VPN**.
 
 ## Global Toggles
 


### PR DESCRIPTION
I removed parentheses, I don't know why they are there.

In my sentence, people could understand that they can buy a Google Pixel **AND** installing a AV app.
I'm wondering if we should recommend that people shouldn't use AV on android at all.