### PR TITLE
Chore: remove link redirect

### DIFF
--- a/docs/linux-desktop/overview.en.md
+++ b/docs/linux-desktop/overview.en.md
@@ -2,7 +2,7 @@
 title: Linux Overview
 icon: fontawesome/brands/linux
 ---
-It is often believed that [open-source](https://en.wikipedia.org/wiki/Open-source_software) software is inherently secure because the source code is available. There is an expectation that community verification occurs regularly; however, this isn’t always [the case](https://seirdy.one/2022/02/02/floss-security.html). It does depend on a number of factors, such as project activity, developer experience, level of rigour applied to [code reviews](https://en.wikipedia.org/wiki/Code_review), and how often attention is given to specific parts of the [codebase](https://en.wikipedia.org/wiki/Codebase) that may go untouched for years.
+It is often believed that [open-source](https://en.wikipedia.org/wiki/Open-source_software) software is inherently secure because the source code is available. There is an expectation that community verification occurs regularly; however, this isn’t always [the case](https://seirdy.one/posts/2022/02/02/floss-security/). It does depend on a number of factors, such as project activity, developer experience, level of rigour applied to [code reviews](https://en.wikipedia.org/wiki/Code_review), and how often attention is given to specific parts of the [codebase](https://en.wikipedia.org/wiki/Codebase) that may go untouched for years.
 
 At the moment, desktop GNU/Linux does have some areas that could be better improved when compared to their proprietary counterparts, e.g.:
 


### PR DESCRIPTION
I migrated my URL format a while back. While I keep re-directs in place
to avoid broken links, it's better to use the canonical version.

(PS: you might wanna take a look at one of the hundreds of broken-link checkers out there. Many of them can pick up unnecessary re-directs.)
