### PR TITLE
Shorten Notification Privacy

### DIFF
--- a/docs/advanced/signal-configuration-hardening.en.md
+++ b/docs/advanced/signal-configuration-hardening.en.md
@@ -136,17 +136,11 @@ Even when your phone is locked, anyone who can lay eyes on the device can read m
 
 On Signal, you have the ability to hide message content and sender name, or just the message content itself.
 
-On Android:
+On Android/iOS:
 
 - Select :material-dots-vertical: **Settings** > **Notifications**
 - Select **Show**
 - Select **No name or message** or **Name only** respectively.
-
-On iOS:
-
-- Select :material-dots-vertical: **Settings** > **Notifications**
-- Select **Show**
-- Select **No name or Content** or **Name Only** respectively.
 
 ### Call Relaying
 


### PR DESCRIPTION
Android and iOS use the exact same text for notification privacy (https://www.privacyguides.org/advanced/signal-configuration-hardening/#notification-privacy) so it can be shortened for conciseness and consistency.

<!-- Please use a descriptive title for your PR, it will be included in our changelog -->

 <!-- Did you solve an open GitHub issue? Put the number here so we mark it complete! -->

<!--
Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well:
Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you must disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->
