### PR TITLE
Update SimpleLogin free aliases number

### DIFF
--- a/docs/email.en.md
+++ b/docs/email.en.md
@@ -278,7 +278,7 @@ You can link your SimpleLogin account in the settings with your Proton account. 
 
 Notable free features:
 
-- [x] 15 Shared Aliases
+- [x] 10 Shared Aliases
 - [x] Unlimited Replies
 - [x] 1 Recipient Mailbox
 


### PR DESCRIPTION

SimpleLogin has updated the maximum aliases on the free plan from 15 to 10 for new users([source](https://www.reddit.com/r/Simplelogin/comments/w16kph/in_the_coming_weeks_we_are_going_to_change_the/)).