### PR TITLE
Replace mention of Scrambled Exif with ExifEraser in Android page

### DIFF
--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -199,7 +199,7 @@ Main privacy features include:
 
     Metadata is not currently deleted from video files but that is planned.
 
-    The image orientation metadata is not deleted. If you enable location (in Secure Camera) that **won't** be deleted either. If you want to delete that later you will need to use an external app such as [Scrambled Exif](https://gitlab.com/juanitobananas/scrambled-exif/).
+    The image orientation metadata is not deleted. If you enable location (in Secure Camera) that **won't** be deleted either. If you want to delete that later you will need to use an external app such as [ExifEraser](data-redaction.md#exiferaser).
 
 ### Secure PDF Viewer
 


### PR DESCRIPTION
We removed Scrambled Exif as a recommendation because of the permissions it requests and replaced it with ExifEraser.

Therefore, it makes sense to consistently reference it across the site.