### PR TITLE
Remove Bitwarden Send card and add info under main Bitwarden card

### DIFF
--- a/docs/file-sharing.en.md
+++ b/docs/file-sharing.en.md
@@ -6,20 +6,6 @@ Discover how to privately share your files between your devices, with your frien
 
 ## File Sharing
 
-### Bitwarden Send
-
-!!! recommendation
-
-    ![Bitwarden logo](assets/img/file-sharing-sync/bitwarden.svg){ align=right }
-
-    **Bitwarden Send** is a tool provided by the [Bitwarden](passwords.md#bitwarden) password manager. It allows you to share text and files securely with [end-to-end encryption](https://bitwarden.com/help/send-encryption). A [password](https://bitwarden.com/help/send-privacy/#send-passwords) can be required along with the send link. Bitwarden Send also features [automatic deletion](https://bitwarden.com/help/send-lifespan).
-
-    You need the [Premium Plan](https://bitwarden.com/help/about-bitwarden-plans/#compare-personal-plans) to be able to share files. Free plan only allows text sharing.
-
-    [:octicons-home-16: Homepage](https://bitwarden.com/products/send/){ .md-button .md-button--primary }
-    [:octicons-info-16:](https://bitwarden.com/help/about-send/){ .card-link title=Documentation}
-    [:octicons-code-16:](https://github.com/bitwarden/clients){ .card-link title="Source Code" }
-
 ### OnionShare
 
 !!! recommendation

--- a/docs/passwords.en.md
+++ b/docs/passwords.en.md
@@ -88,6 +88,10 @@ These password managers sync your passwords to a cloud server for easy accessibi
         - [:fontawesome-brands-chrome: Chrome](https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb)
         - [:fontawesome-brands-edge: Edge](https://microsoftedge.microsoft.com/addons/detail/jbkfoedolllekgbhcbcoahefnbanhhlh)
 
+Bitwarden also features [Bitwarden Send](https://bitwarden.com/products/send/), which allows you to share text and files securely with [end-to-end encryption](https://bitwarden.com/help/send-encryption). A [password](https://bitwarden.com/help/send-privacy/#send-passwords) can be required along with the send link. Bitwarden Send also features [automatic deletion](https://bitwarden.com/help/send-lifespan).
+
+You need the [Premium Plan](https://bitwarden.com/help/about-bitwarden-plans/#compare-personal-plans) to be able to share files. The free plan only allows text sharing.
+
 Bitwarden's server-side code is [open-source](https://github.com/bitwarden/server), so if you don't want to use the Bitwarden cloud, you can easily host your own Bitwarden sync server.
 
 **Vaultwarden** is an alternative implementation of the Bitwarden server API written in Rust and compatible with upstream Bitwarden clients, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.

--- a/docs/tools.en.md
+++ b/docs/tools.en.md
@@ -313,7 +313,6 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 <div class="grid cards" markdown>
 
-- ![Bitwarden logo](assets/img/file-sharing-sync/bitwarden.svg){ .twemoji } [Bitwarden](file-sharing.md#bitwarden-send)
 - ![OnionShare logo](assets/img/file-sharing-sync/onionshare.svg){ .twemoji } [OnionShare](file-sharing.md#onionshare)
 - ![FreedomBox logo](assets/img/file-sharing-sync/freedombox.svg){ .twemoji } [FreedomBox](file-sharing.md#freedombox)
 - ![Syncthing logo](assets/img/file-sharing-sync/syncthing.svg){ .twemoji } [Syncthing](file-sharing.md#syncthing)


### PR DESCRIPTION
Bitwarden Send is a feature of Bitwarden, and while they may have chosen to market it as a separate thing, I think listing Bitwarden twice is confusing to our readers.

If this gets merged, we can then mention Bitwarden Send and other projects that feature file sharing in some capacity (Proton Drive would be an example) somewhere in the File Sharing page.