### PR TITLE
Small fixes in Data Redaction Page

### DIFF
--- a/docs/data-redaction.en.md
+++ b/docs/data-redaction.en.md
@@ -91,8 +91,6 @@ The app offers multiple ways to erase metadata from images. Namely:
 
     Metapho is a simple and clean viewer for photo metadata such as date, file name, size, camera model, shutter speed, and location.
 
-    Metapho is closed-source, however we recommend it due to the few choices there are for iOS.
-
     [:octicons-home-16: Homepage](https://zininworks.com/metapho){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://zininworks.com/privacy/){ .card-link title="Privacy Policy" }
 
@@ -120,7 +118,7 @@ The app offers multiple ways to erase metadata from images. Namely:
 
 !!! warning
 
-    You should **never** use blur to redact [text in images](https://bishopfox.com/blog/unredacter-tool-never-pixelation). If you want to redact text in an image, draw a box over the text. For this we suggest [Pocket Paint](https://github.com/Catrobat/Paintroid) or [Imagepipe](https://codeberg.org/Starfish/Imagepipe).
+    You should **never** use blur to redact [text in images](https://bishopfox.com/blog/unredacter-tool-never-pixelation). If you want to redact text in an image, draw a box over the text. For this, we suggest apps like [Pocket Paint](https://github.com/Catrobat/Paintroid).
 
 ## Command-line
 


### PR DESCRIPTION
This PR has two minor fixes:

- Removes mention of Metapho being closed source. Open source is not a requirement, and we also have a source code button for open source recommendations, so readers know what software is open and what is closed. Mentioning it gives it a negative connotation which is not fair.
- Removes mention of Imagepipe under the PrivacyBlur recommendation that was recently moved from the Android page. Imagepipe is not available on the Play Store, while Pocket Paint is (as well as F-droid, if people want that) and it seems a lot more popular and polished (over a million downloads on Play Store). We also[ removed Imagepipe for requesting unnecessary permissions](https://github.com/privacyguides/privacyguides.org/pull/1471), so it doesn't make sense to recommend it elsewhere on the site.

