### PR TITLE
Changed utilize to use

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -50,7 +50,7 @@ It's important for a website like Privacy Guides to always stay up-to-date. We n
 
 **Privacy Guides** is a non-profit, socially motivated website that provides information for protecting your data security and privacy.
 
-We do not make money from recommending certain products, and we do not utilize affiliate links.
+We do not make money from recommending certain products, and we do not use affiliate links.
 <div class="grid cards" style="margin:auto;max-width:800px;text-align:center;" markdown>
 
 - [:material-information-outline: Learn More About Us](about/)


### PR DESCRIPTION
Changed 'utilize' in the footer to 'user', because the former is a terrible word that we should not _use_. It's not very freindly, and its long and clunky too.

> Utilize means “to make use of,” of course. I wonder what else means that. Oh, right: Use. Merriam-Webster's first definition for use as a transitive verb — after the archaic habituate — is “to put into action or service : avail oneself of : employ.” Employ, by the way, is another synonym for utilize.

(Source: [“Utilize” is the worst word in the English language](https://theoutline.com/post/2151/utilize-is-the-worst-word-in-the-english-language)).

---

*Sorry if this is a bit scuffed - trying some things I don't entirely understand yet.*