### PR TITLE
Increase GrapheneOS user profile count to 32

### DIFF
--- a/docs/android/grapheneos-vs-calyxos.en.md
+++ b/docs/android/grapheneos-vs-calyxos.en.md
@@ -9,7 +9,7 @@ GrapheneOS and CalyxOS are often compared as similar options for people looking 
 
 CalyxOS has a track record of being slower to apply security and feature updates to its OS and core applications than other custom Android operating systems. Timely security updates are one of the most important factors to consider when determining whether an OS is secure enough for regular use, which is a requirement for privacy.
 
-In contrast to that, GrapheneOS manages to stay close to upstream and in some cases even [deliver updates even before the stock OS does](https://grapheneos.org/features#more-complete-patching).
+In contrast to that, GrapheneOS manages to stay close to upstream and in some cases even [deliver updates before the stock OS does](https://grapheneos.org/features#more-complete-patching).
 
 As an example, [GrapheneOS's first Android 12 release](https://grapheneos.org/releases#2021102020) was in October 2021, whereas [CalyxOS moved to Android 12](https://calyxos.org/news/2022/01/19/android-12-changelog/) in January 2022.
 


### PR DESCRIPTION
Small fix for the GrapheneOS/CalyxOS page. GrapheneOS just released an update the raised the amount of possible user profiles to 32 from 16.

Source: https://grapheneos.org/releases#2022091300