### PR TITLE
Standardize download sections

### DIFF
--- a/docs/android.en.md
+++ b/docs/android.en.md
@@ -136,7 +136,6 @@ We recommend a wide variety of Android apps throughout this site. The apps liste
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=net.typeblog.shelter)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/net.typeblog.shelter)
 
 !!! warning
 
@@ -252,7 +251,6 @@ The Google Play Store requires a Google account to login which is not great for 
 
     ??? downloads
 
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/com.aurora.store/)
         - [:simple-gitlab: GitLab](https://gitlab.com/AuroraOSS/AuroraStore/-/releases)
 
 Aurora Store does not allow you to download paid apps with their anonymous account feature. You can optionally log in with your Google account with Aurora Store to download apps you have purchased, which does give access to the list of apps you've installed to Google, however you still benefit from not requiring the full Google Play client and Google Play Services or microG on your device.

--- a/docs/calendar-contacts.en.md
+++ b/docs/calendar-contacts.en.md
@@ -23,14 +23,13 @@ Calendars and contacts contain some of your most sensitive data; use products th
 
     ??? downloads
 
-        - [:octicons-browser-16: Web](https://mail.tutanota.com/)
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=de.tutao.tutanota)
+        - [:simple-appstore: App Store](https://apps.apple.com/us/app/tutanota/id922429609)
         - [:simple-windows11: Windows](https://tutanota.com/blog/posts/desktop-clients/)
         - [:simple-apple: macOS](https://tutanota.com/blog/posts/desktop-clients/)
         - [:simple-linux: Linux](https://tutanota.com/blog/posts/desktop-clients/)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/com.tutanota.Tutanota)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=de.tutao.tutanota)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/de.tutao.tutanota)
-        - [:simple-appstore: App Store](https://apps.apple.com/us/app/tutanota/id922429609)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/com.tutanota.Tutanota)
+        - [:octicons-browser-16: Web](https://mail.tutanota.com/)
 
 ## EteSync
 
@@ -50,10 +49,9 @@ Calendars and contacts contain some of your most sensitive data; use products th
 
     ??? downloads
 
-        - [:octicons-device-desktop-16: Client Setup](https://github.com/etesync/etesync-dav/blob/master/README.md#specific-client-notes-and-instructions)
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.etesync.syncadapter)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/app/com.etesync.syncadapter)
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/apple-store/id1489574285)
+        - [:octicons-device-desktop-16: Client Setup](https://github.com/etesync/etesync-dav/blob/master/README.md#specific-client-notes-and-instructions)
         - [:simple-docker: Docker Hub](https://hub.docker.com/r/victorrds/etesync)
 
 ## Proton Calendar
@@ -73,8 +71,8 @@ Calendars and contacts contain some of your most sensitive data; use products th
 
     ??? downloads
 
-        - [:octicons-browser-16: Web](https://calendar.proton.me)
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=me.proton.android.calendar)
+        - [:octicons-browser-16: Web](https://calendar.proton.me)
 
 !!! warning
     Proton [does not](https://proton.me/support/proton-contacts#verify) use E2EE for your contact names and email addresses.

--- a/docs/cloud.en.md
+++ b/docs/cloud.en.md
@@ -22,6 +22,10 @@ If these alternatives do not fit your needs, we suggest you look into [Encryptio
     [:octicons-info-16:](https://crypt.ee/help){ .card-link title=Documentation}
     [:octicons-code-16:](https://github.com/cryptee){ .card-link title="Source Code" }
 
+    ??? downloads
+    
+        - [:octicons-globe-16: PWA](https://crypt.ee/download)
+
 ## Nextcloud
 
 !!! recommendation
@@ -38,15 +42,15 @@ If these alternatives do not fit your needs, we suggest you look into [Encryptio
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.nextcloud.client)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id1125420102)
+        - [:simple-github: GitHub](https://github.com/nextcloud/android/releases)
         - [:simple-windows11: Windows](https://nextcloud.com/install/#install-clients)
         - [:simple-apple: macOS](https://nextcloud.com/install/#install-clients)
         - [:simple-linux: Linux](https://nextcloud.com/install/#install-clients)
         - [:simple-freebsd: FreeBSD](https://www.freshports.org/www/nextcloud)
         - [:simple-openbsd: OpenBSD](https://openports.se/www/nextcloud)
         - [:simple-netbsd: NetBSD](https://pkgsrc.se/www/php-nextcloud)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.nextcloud.client)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/com.nextcloud.client)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/id1125420102)
 
 We recommend checking if your Nextcloud provider supports E2EE, otherwise you have to trust the provider to not look at your files.
 

--- a/docs/data-redaction.en.md
+++ b/docs/data-redaction.en.md
@@ -64,7 +64,6 @@ When sharing files, be sure to remove associated metadata. Image files commonly 
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.none.tom.exiferaser)
-        - [:simple-android: IzzyOnDroid (APK)](https://android.izzysoft.de/repo/apk/com.none.tom.exiferaser)
         - [:simple-github: GitHub](https://github.com/Tommy-Geenexus/exif-eraser/releases)
 
 The metadata that is erased depends on the image's file type:
@@ -114,7 +113,6 @@ The app offers multiple ways to erase metadata from images. Namely:
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=de.mathema.privacyblur)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/de.mathema.privacyblur/)
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/privacyblur/id1536274106)
 
 !!! warning

--- a/docs/desktop-browsers.en.md
+++ b/docs/desktop-browsers.en.md
@@ -23,7 +23,7 @@ These are our currently recommended desktop web browsers and configurations for 
         - [:simple-windows11: Windows](https://www.mozilla.org/firefox/windows)
         - [:simple-apple: macOS](https://www.mozilla.org/firefox/mac)
         - [:simple-linux: Linux](https://www.mozilla.org/firefox/linux)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.mozilla.firefox)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.mozilla.firefox)
 
 !!! warning
     Firefox includes a unique [download token](https://bugzilla.mozilla.org/show_bug.cgi?id=1677497#c0) in downloads from Mozilla's website and uses telemetry in Firefox to send the token. The token is **not** included in releases from the [Mozilla FTP](https://ftp.mozilla.org/pub/firefox/releases/).
@@ -98,6 +98,7 @@ The [Arkenfox project](https://github.com/arkenfox/user.js) provides a set of ca
 
     ??? downloads annotate
 
+        - [:simple-github: GitHub](https://github.com/brave/brave-browser/releases)
         - [:simple-windows11: Windows](https://brave.com/download/)
         - [:simple-apple: macOS](https://brave.com/download/)
         - [:simple-linux: Linux](https://brave.com/linux/) (1)

--- a/docs/dns.en.md
+++ b/docs/dns.en.md
@@ -93,7 +93,7 @@ Encrypted DNS proxy software provides a local proxy for the [unencrypted DNS](ba
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.celzero.bravedns)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/com.celzero.bravedns)
+        - [:simple-github: GitHub](https://github.com/celzero/rethink-app/releases)
 
 ### dnscrypt-proxy
 

--- a/docs/email-clients.en.md
+++ b/docs/email-clients.en.md
@@ -31,7 +31,7 @@ Our recommendation list contains email clients that support both [OpenPGP](encry
         - [:simple-windows11: Windows](https://www.thunderbird.net)
         - [:simple-apple: macOS](https://www.thunderbird.net)
         - [:simple-linux: Linux](https://www.thunderbird.net)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.mozilla.Thunderbird)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.mozilla.Thunderbird)
 
 ## Platform Specific
 
@@ -61,10 +61,9 @@ Our recommendation list contains email clients that support both [OpenPGP](encry
 
     ??? downloads
 
-        - [:simple-apple: Mac App Store](https://apps.apple.com/app/id1236045954)
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.canarymail.android)
         - [:simple-appstore: App Store](https://apps.apple.com/app/id1236045954)
         - [:simple-windows11: Windows](https://canarymail.io/downloads.html)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.canarymail.android)
 
 !!! attention
 
@@ -89,7 +88,7 @@ Canary Mail is closed-source. We recommend it due to the few choices there are f
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=eu.faircode.email)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/eu.faircode.email/)
+        - [:simple-github: GitHub](https://github.com/M66B/FairEmail/releases)
 
 ### GNOME Evolution (GNOME)
 
@@ -107,7 +106,7 @@ Canary Mail is closed-source. We recommend it due to the few choices there are f
 
     ??? downloads
 
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.gnome.Evolution)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.gnome.Evolution)
 
 ### K-9 Mail (Android)
 
@@ -128,7 +127,6 @@ Canary Mail is closed-source. We recommend it due to the few choices there are f
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.fsck.k9)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/com.fsck.k9)
         - [:simple-github: GitHub](https://github.com/k9mail/k-9/releases)
 
 ### Kontact (KDE)
@@ -148,7 +146,7 @@ Canary Mail is closed-source. We recommend it due to the few choices there are f
     ??? downloads
 
         - [:simple-linux: Linux](https://kontact.kde.org/download)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.kde.kontact)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.kde.kontact)
 
 ### Mailvelope (Browser)
 
@@ -186,5 +184,5 @@ Canary Mail is closed-source. We recommend it due to the few choices there are f
 
     ??? downloads
 
-        - [:simple-linux: Linux](https://neomutt.org/distro)
         - [:simple-apple: macOS](https://neomutt.org/distro)
+        - [:simple-linux: Linux](https://neomutt.org/distro)

--- a/docs/email.en.md
+++ b/docs/email.en.md
@@ -34,6 +34,16 @@ For everything else, we recommend a variety of email providers based on sustaina
     [:octicons-info-16:](https://proton.me/support/mail){ .card-link title=Documentation}
     [:octicons-code-16:](https://github.com/ProtonMail){ .card-link title="Source Code" }
 
+    ??? downloads
+
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=ch.protonmail.android)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/apple-store/id979659905)
+        - [:simple-github: GitHub](https://github.com/ProtonMail/proton-mail-android/releases)
+        - [:simple-windows11: Windows](https://proton.me/mail/bridge#download)
+        - [:simple-apple: macOS](https://proton.me/mail/bridge#download)
+        - [:simple-linux: Linux](https://proton.me/mail/bridge#download)
+        - [:octicons-browser-16: Web](https://mail.proton.me)
+
 ??? check "Custom Domains and Aliases"
 
     Paid Proton Mail subscribers can use their own domain with the service or a [catch-all](https://proton.me/support/catch-all) address. Proton Mail also supports [subaddressing](https://proton.me/support/creating-aliases), which is useful for people who don't want to purchase a domain.
@@ -73,6 +83,10 @@ For everything else, we recommend a variety of email providers based on sustaina
     [:octicons-home-16: Homepage](https://mailbox.org){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://mailbox.org/en/data-protection-privacy-policy){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://kb.mailbox.org/en/private){ .card-link title=Documentation}
+
+    ??? downloads
+
+        - [:octicons-browser-16: Web](https://login.mailbox.org)
 
 ??? check "Custom Domains and Aliases"
 
@@ -117,6 +131,10 @@ For everything else, we recommend a variety of email providers based on sustaina
     [:octicons-eye-16:](https://www.startmail.com/en/privacy/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.startmail.com){ .card-link title=Documentation}
 
+    ??? downloads
+
+        - [:octicons-browser-16: Web](https://mail.startmail.com/login)
+
 ??? check "Custom Domains and Aliases"
 
     Personal accounts can use [Custom or Quick](https://support.startmail.com/hc/en-us/articles/360007297457-Aliases) aliases. [Custom domains](https://support.startmail.com/hc/en-us/articles/4403911432209-Setup-a-custom-domain) are also available.
@@ -157,11 +175,19 @@ For everything else, we recommend a variety of email providers based on sustaina
     [:octicons-code-16:](https://github.com/tutao/tutanota){ .card-link title="Source Code" }
     [:octicons-heart-16:](https://tutanota.com/community/){ .card-link title=Contribute }
 
+    ??? downloads
+
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=de.tutao.tutanota)
+        - [:simple-appstore: App Store](https://itunes.apple.com/de/app/tutanota/id922429609)
+        - [:simple-github: GitHub](https://github.com/tutao/tutanota/releases)
+        - [:simple-windows11: Windows](https://tutanota.com/#download)
+        - [:simple-apple: macOS](https://tutanota.com/#download)
+        - [:simple-linux: Linux](https://tutanota.com/#download)
+        - [:octicons-browser-16: Web](https://mail.tutanota.com/)
+
 Tutanota [doesn't allow](https://tutanota.com/faq/#imap) the use of third-party [email clients](email-clients.md). Tutanota has no plans pull email from [external email accounts](https://github.com/tutao/tutanota/issues/544#issuecomment-670473647) using the IMAP protocol. [Email import](https://github.com/tutao/tutanota/issues/630) is currently not possible.
 
 Emails can be exported [individually or by bulk selection](https://tutanota.com/howto#generalMail). Tutanota does not allow for [subfolders](https://github.com/tutao/tutanota/issues/927) as you might expect with other email providers.
-
-Tutanota is working on a [desktop client](https://tutanota.com/blog/posts/desktop-clients/) and they have an app [available in F-Droid](https://f-droid.org/packages/de.tutao.tutanota). They also have their app in conventional stores such as [App Store](https://apps.apple.com/us/app/tutanota/id922429609) on iOS and [Google Play](https://play.google.com/store/apps/details?id=de.tutao.tutanota) for Android.
 
 ??? check "Custom Domains and Aliases"
 
@@ -228,10 +254,11 @@ Using an aliasing service requires trusting both your email provider and your al
     [:octicons-heart-16:](https://anonaddy.com/donate/){ .card-link title=Contribute }
 
     ??? downloads
+
+        - [:simple-android: Android](https://anonaddy.com/faq/#is-there-an-android-app)
+        - [:material-apple-ios: iOS](https://anonaddy.com/faq/#is-there-an-ios-app)
         - [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/en-GB/firefox/addon/anonaddy/)
         - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/anonaddy-anonymous-email/iadbdpnoknmbdeolbapdackdcogdmjpe)
-        - [:material-apple-ios: iOS](https://anonaddy.com/faq/#is-there-an-ios-app)
-        - [:simple-android: Android](https://anonaddy.com/faq/#is-there-an-android-app)
 
 The number of shared aliases (which end in a shared domain like @anonaddy.me) that you can create is limited to 20 on AnonAddy's free plan and 50 on their $12/year plan. You can create unlimited standard aliases (which end in a domain like @[username].anonaddy.com or a custom domain on paid plans), however, as previously mentioned, this can be detrimental to privacy because people can trivially tie your standard aliases together based on the domain name alone. Unlimited shared aliases are available for $36/year.
 
@@ -257,13 +284,14 @@ Notable free features:
     [:octicons-code-16:](https://github.com/simple-login){ .card-link title="Source Code" }
 
     ??? downloads
+    
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.simplelogin.android)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id1494359858)
+        - [:simple-github: GitHub](https://github.com/simple-login/Simple-Login-Android/releases)
         - [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/en-US/firefox/addon/simplelogin/)
         - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/dphilobhebphkdjbpfohgikllaljmgbn)
         - [:simple-microsoftedge: Edge](https://microsoftedge.microsoft.com/addons/detail/simpleloginreceive-sen/diacfpipniklenphgljfkmhinphjlfff)
         - [:simple-safari: Safari](https://apps.apple.com/app/id1494051017)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/id1494359858)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.simplelogin.android)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/io.simplelogin.android.fdroid/)
 
 SimpleLogin was [acquired by Proton AG](https://proton.me/news/proton-and-simplelogin-join-forces) as of April 8, 2022. If you use Proton Mail for your primary mailbox, SimpleLogin is a great choice. As both products are now owned by the same company you now only have to trust a single entity. We also expect that SimpleLogin will be more tightly integrated with Proton's offerings in the future. SimpleLogin continues to support forwarding to any email provider of your choosing. Securitum [audited](https://simplelogin.io/blog/security-audit/) SimpleLogin in early 2022 and all issues [were addressed](https://simplelogin.io/audit2022/web.pdf).
 

--- a/docs/encryption.en.md
+++ b/docs/encryption.en.md
@@ -24,13 +24,13 @@ The options listed here are multi-platform and great for creating encrypted back
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.cryptomator)
+        - [:simple-appstore: App Store](https://apps.apple.com/us/app/cryptomator-2/id1560822163)
+        - [:simple-android: Android](https://cryptomator.org/android)
         - [:simple-windows11: Windows](https://cryptomator.org/downloads)
         - [:simple-apple: macOS](https://cryptomator.org/downloads)
         - [:simple-linux: Linux](https://cryptomator.org/downloads)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.cryptomator.Cryptomator)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.cryptomator)
-        - [:simple-android: Android](https://cryptomator.org/android)
-        - [:simple-appstore: App Store](https://apps.apple.com/us/app/cryptomator-2/id1560822163)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.cryptomator.Cryptomator)
 
 Cryptomator uses AES-256 encryption to encrypt both files and filenames. Cryptomator cannot encrypt metadata such as access, modification, and creation timestamps, nor the number and size of files and folders.
 
@@ -267,10 +267,10 @@ When encrypting with PGP, you have the option to configure different options in 
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.sufficientlysecure.keychain)
         - [:simple-windows11: Windows](https://gpg4win.org/download.html)
         - [:simple-apple: macOS](https://gpgtools.org)
         - [:simple-linux: Linux](https://gnupg.org/download/index.html#binary)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.sufficientlysecure.keychain)
 
 ### GPG4win
 
@@ -330,4 +330,3 @@ When encrypting with PGP, you have the option to configure different options in 
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.sufficientlysecure.keychain)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/org.sufficientlysecure.keychain/)

--- a/docs/file-sharing.en.md
+++ b/docs/file-sharing.en.md
@@ -55,11 +55,10 @@ Discover how to privately share your files between your devices, with your frien
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid)
         - [:simple-windows11: Windows](https://syncthing.net/downloads/)
         - [:simple-apple: macOS](https://syncthing.net/downloads/)
         - [:simple-linux: Linux](https://syncthing.net/downloads/)
         - [:simple-freebsd: FreeBSD](https://syncthing.net/downloads/)
         - [:simple-openbsd: OpenBSD](https://syncthing.net/downloads/)
         - [:simple-netbsd: NetBSD](https://syncthing.net/downloads/)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/com.nutomic.syncthingandroid/)

--- a/docs/frontends.en.md
+++ b/docs/frontends.en.md
@@ -84,7 +84,7 @@ When you are using a Nitter instance, make sure to read the privacy policy of th
         - [:simple-windows11: Windows](https://freetubeapp.io/#download)
         - [:simple-apple: macOS](https://freetubeapp.io/#download)
         - [:simple-linux: Linux](https://freetubeapp.io/#download)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/io.freetubeapp.FreeTube)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/io.freetubeapp.FreeTube)
 
 !!! Warning
 
@@ -109,14 +109,9 @@ When you are using a Nitter instance, make sure to read the privacy policy of th
 
     ??? downloads
 
-        - [:simple-fdroid: F-Droid](https://newpipe.net/FAQ/tutorials/install-add-fdroid-repo)
         - [:simple-github: GitHub](https://github.com/TeamNewPipe/NewPipe/releases)
 
 1. The default instance is [FramaTube](https://framatube.org/), however more can be added via **Settings** → **Content** → **PeerTube instances**
-
-!!! note
-
-    NewPipe is available on the main [F-Droid](https://www.f-droid.org)'s repository. We recommend that you use NewPipe's own [F-Droid repository](https://newpipe.net/FAQ/tutorials/install-add-fdroid-repo) instead to get faster updates.
 
 !!! Warning
     

--- a/docs/mobile-browsers.en.md
+++ b/docs/mobile-browsers.en.md
@@ -27,6 +27,7 @@ On Android, Firefox is still less secure than Chromium-based alternatives: Mozil
     ??? downloads annotate
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.brave.browser)
+        - [:simple-github: GitHub](https://github.com/brave/brave-browser/releases)
 
 #### Recommended Configuration
 

--- a/docs/multi-factor-authentication.en.md
+++ b/docs/multi-factor-authentication.en.md
@@ -84,7 +84,6 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/com.beemdevelopment.aegis)
         - [:simple-github: GitHub](https://github.com/beemdevelopment/Aegis/releases)
 
 ### Raivo OTP
@@ -103,4 +102,3 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
     ??? downloads
 
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/raivo-otp/id1459042137)
-        - [:simple-apple: Mac App Store](https://apps.apple.com/us/app/raivo-otp/id1498497896)

--- a/docs/news-aggregators.en.md
+++ b/docs/news-aggregators.en.md
@@ -23,7 +23,7 @@ A [news aggregator](https://en.wikipedia.org/wiki/News_aggregator) is a way to k
 
     ??? downloads
 
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.kde.akregator)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.kde.akregator)
 
 ### Feeder
 
@@ -40,7 +40,6 @@ A [news aggregator](https://en.wikipedia.org/wiki/News_aggregator) is a way to k
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.nononsenseapps.feeder.play)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/com.nononsenseapps.feeder/)
 
 ### Fluent Reader
 
@@ -59,7 +58,7 @@ A [news aggregator](https://en.wikipedia.org/wiki/News_aggregator) is a way to k
     ??? downloads
 
         - [:simple-windows11: Windows](https://hyliu.me/fluent-reader)
-        - [:simple-apple: Mac App Store](https://apps.apple.com/app/id1520907427)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id1520907427)
 
 ### GNOME Feeds
 
@@ -76,7 +75,7 @@ A [news aggregator](https://en.wikipedia.org/wiki/News_aggregator) is a way to k
     ??? downloads
 
         - [:simple-linux: Linux](https://gfeeds.gabmus.org/#install)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.gabmus.gfeeds)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.gabmus.gfeeds)
 
 ### Miniflux
 
@@ -107,8 +106,8 @@ A [news aggregator](https://en.wikipedia.org/wiki/News_aggregator) is a way to k
 
     ??? downloads
 
-        - [:simple-apple: macOS](https://netnewswire.com)
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/netnewswire-rss-reader/id1480640210)
+        - [:simple-apple: macOS](https://netnewswire.com)
 
 ### Newsboat
 

--- a/docs/notebooks.en.md
+++ b/docs/notebooks.en.md
@@ -28,7 +28,6 @@ If you are currently using an application like Evernote, Google Keep, or Microso
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.etesync.notes)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/com.etesync.notes)
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/etesync-notes/id1533806351)
         - [:octicons-globe-16: Web](https://notes.etesync.com)
 
@@ -48,13 +47,14 @@ If you are currently using an application like Evernote, Google Keep, or Microso
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=net.cozic.joplin)
+        - [:simple-appstore: App Store](https://apps.apple.com/us/app/joplin/id1315599797)
+        - [:simple-github: GitHub](https://github.com/laurent22/joplin-android/releases)
         - [:simple-windows11: Windows](https://joplinapp.org/#desktop-applications)
         - [:simple-apple: macOS](https://joplinapp.org/#desktop-applications)
         - [:simple-linux: Linux](https://joplinapp.org/#desktop-applications)
         - [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/firefox/addon/joplin-web-clipper/)
         - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/joplin-web-clipper/alofnhikmmkdbbbgpnglcpdollgjjfek)
-        - [:simple-appstore: App Store](https://apps.apple.com/us/app/joplin/id1315599797)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=net.cozic.joplin)
 
 Joplin does not support password/PIN protection for the [application itself or individual notes and notebooks](https://github.com/laurent22/joplin/issues/289). However, your data is still encrypted in transit and at the sync location using your master key.
   
@@ -74,12 +74,12 @@ Joplin does not support password/PIN protection for the [application itself or i
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.standardnotes)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id1285392450)
+        - [:simple-github: GitHub](https://github.com/standardnotes/app/releases)
         - [:simple-windows11: Windows](https://standardnotes.com)
         - [:simple-apple: macOS](https://standardnotes.com)
         - [:simple-linux: Linux](https://standardnotes.com)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/id1285392450)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.standardnotes)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/en/packages/com.standardnotes)
         - [:octicons-globe-16: Web](https://app.standardnotes.com/)
 
 ## Local notebooks

--- a/docs/passwords.en.md
+++ b/docs/passwords.en.md
@@ -25,13 +25,12 @@ These password managers sync your passwords to a cloud server for easy accessibi
 
     ??? downloads
 
-        - [:simple-windows11: Windows](https://bitwarden.com/download)
-        - [:simple-apple: Mac App Store](https://apps.apple.com/app/bitwarden/id1352778147)
-        - [:simple-linux: Linux](https://bitwarden.com/download)
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/com.bitwarden.desktop)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/bitwarden-password-manager/id1137397744)
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.x8bit.bitwarden)
-        - [:simple-fdroid: F-Droid](https://mobileapp.bitwarden.com/fdroid)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/bitwarden-password-manager/id1137397744)
+        - [:simple-github: GitHub](https://github.com/bitwarden/mobile/releases)
+        - [:simple-windows11: Windows](https://bitwarden.com/download)
+        - [:simple-linux: Linux](https://bitwarden.com/download)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/com.bitwarden.desktop)
         - [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/firefox/addon/bitwarden-password-manager)
         - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb)
         - [:simple-microsoftedge: Edge](https://microsoftedge.microsoft.com/addons/detail/jbkfoedolllekgbhcbcoahefnbanhhlh)
@@ -61,6 +60,15 @@ Bitwarden's server-side code is [open-source](https://github.com/bitwarden/serve
     [:octicons-eye-16:](https://support.1password.com/1password-privacy/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.1password.com/){ .card-link title=Documentation}
 
+    ??? downloads
+
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.onepassword.android)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id1511601750?mt=8)
+        - [:simple-windows11: Windows](https://1password.com/downloads/windows/)
+        - [:simple-apple: macOS](https://1password.com/downloads/mac/)
+        - [:simple-linux: Linux](https://1password.com/downloads/linux/)
+        
+
 Traditionally, **1Password** has offered the best password manager user experience for people using macOS and iOS; however, it has now achieved feature-parity across all platforms. It boasts many features geared towards families and less technical people, as well as advanced functionality.
 
 Your 1Password vault is secured with both your master password and a randomized 34-character security key to encrypt your data on their servers. This security key adds a layer of protection to your data because your data is secured with high entropy regardless of your master password. Many other password manager solutions are entirely reliant on the strength of your master password to secure your data.
@@ -82,10 +90,10 @@ One advantage 1Password has over Bitwarden is its first-class support for native
 
     ??? downloads
 
-        - [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/firefox/addon/psono-pw-password-manager)
-        - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/psonopw-password-manager/eljmjmgjkbmpmfljlmklcfineebidmlo)
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.psono.psono)
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/psono-password-manager/id1545581224)
+        - [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/firefox/addon/psono-pw-password-manager)
+        - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/psonopw-password-manager/eljmjmgjkbmpmfljlmklcfineebidmlo)
         - [:simple-docker: Docker Hub](https://hub.docker.com/r/psono/psono-client)
 
 Psono provides [extensive documentation](https://doc.psono.com/) for their product. The [web-client](https://doc.psono.com/admin/installation/install-webclient.html#installation-with-docker) for Psono can be self-hosted; alternatively, you can choose the full [Community Edition](https://doc.psono.com/admin/installation/install-server-ce.html) or the [Enterprise Edition](https://doc.psono.com/admin/installation/install-server-ee.html) with additional features.
@@ -135,7 +143,6 @@ KeePassXC stores its export data as [CSV](https://en.wikipedia.org/wiki/Comma-se
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.kunzisoft.keepass.free)
-        - [:simple-fdroid: F-Droid](https://www.f-droid.org/packages/com.kunzisoft.keepass.libre)
         - [:simple-github: GitHub](https://github.com/Kunzisoft/KeePassDX/releases)
 
 ### Strongbox (iOS & macOS)
@@ -154,7 +161,6 @@ KeePassXC stores its export data as [CSV](https://en.wikipedia.org/wiki/Comma-se
 
     ??? downloads
 
-        - [:simple-apple: Mac App Store](https://apps.apple.com/app/strongbox-keepass-pwsafe/id897283731)
         - [:simple-appstore: App Store](https://apps.apple.com/app/strongbox-keepass-pwsafe/id897283731)
 
 There is also an offline-only version available called [Strongbox Zero](https://apps.apple.com/us/app/strongbox-keepass-pwsafe/id1581589638) if you don't need syncing; this version is stripped down so it has less attack surface.

--- a/docs/productivity.en.md
+++ b/docs/productivity.en.md
@@ -26,15 +26,15 @@ For other platforms, consider below:
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://www.libreoffice.org/download/android-and-ios/)
+        - [:simple-appstore: App Store](https://www.libreoffice.org/download/android-and-ios/)
         - [:simple-windows11: Windows](https://www.libreoffice.org/download/download/)
         - [:simple-apple: macOS](https://www.libreoffice.org/download/download/)
         - [:simple-linux: Linux](https://www.libreoffice.org/download/download/)
-        - [:simple-flathub: Flatpak](https://www.libreoffice.org/download/download/)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.libreoffice.LibreOffice)
         - [:simple-freebsd: FreeBSD](https://www.freshports.org/editors/libreoffice/)
         - [:simple-openbsd: OpenBSD](https://openports.se/editors/libreoffice)
         - [:simple-netbsd: NetBSD](https://pkgsrc.se/misc/libreoffice)
-        - [:simple-googleplay: Google Play](https://www.libreoffice.org/download/android-and-ios/)
-        - [:simple-appstore: App Store](https://www.libreoffice.org/download/android-and-ios/)
 
 ### OnlyOffice
 
@@ -51,12 +51,12 @@ For other platforms, consider below:
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.onlyoffice.documents)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id944896972)
         - [:simple-windows11: Windows](https://www.onlyoffice.com/download-desktop.aspx)
         - [:simple-apple: macOS](https://www.onlyoffice.com/download-desktop.aspx)
         - [:simple-linux: Linux](https://www.onlyoffice.com/download-desktop.aspx)
         - [:simple-freebsd: FreeBSD](https://www.freshports.org/www/onlyoffice-documentserver/)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.onlyoffice.documents)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/id944896972)
 
 ### CryptPad
 

--- a/docs/real-time-communication.en.md
+++ b/docs/real-time-communication.en.md
@@ -27,11 +27,12 @@ These are our recommendations for encrypted real-time communication.
 
     ??? downloads
 
-        - [:simple-windows11: Windows](https://signal.org/download)
-        - [:simple-apple: macOS](https://signal.org/download)
-        - [:simple-linux: Linux](https://signal.org/download)
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.thoughtcrime.securesms)
         - [:simple-appstore: App Store](https://apps.apple.com/app/id874139669)
+        - [:simple-android: Android](https://signal.org/android/apk/)
+        - [:simple-windows11: Windows](https://signal.org/download/windows)
+        - [:simple-apple: macOS](https://signal.org/download/macos)
+        - [:simple-linux: Linux](https://signal.org/download/linux)
 
 Signal supports [private groups](https://signal.org/blog/signal-private-group-system/). The server has no record of your group memberships, group titles, group avatars, or group attributes. Signal has minimal metadata when [Sealed Sender](https://signal.org/blog/sealed-sender/) is enabled. The sender address is encrypted along with the message body, and only the recipient address is visible to the server. Sealed Sender is only enabled for people in your contacts list, but can be enabled for all recipients with the increased risk of receiving spam. Signal requires your phone number as a personal identifier.
 
@@ -58,13 +59,13 @@ We have some additional tips on configuring and hardening your Signal installati
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=im.vector.app)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/vector/id1083446067)
+        - [:simple-github: GitHub](https://github.com/vector-im/element-android/releases)
         - [:simple-windows11: Windows](https://element.io/get-started)
         - [:simple-apple: macOS](https://element.io/get-started)
         - [:simple-linux: Linux](https://element.io/get-started)
         - [:octicons-globe-16: Web](https://app.element.io)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=im.vector.app)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/im.vector.app/)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/vector/id1083446067)
 
 Profile pictures, reactions, and nicknames are not encrypted.
 
@@ -89,12 +90,12 @@ The protocol was independently [audited](https://matrix.org/blog/2016/11/21/matr
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=network.loki.messenger)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/id1470168868)
+        - [:simple-github: GitHub](https://github.com/oxen-io/session-android/releases)
         - [:simple-windows11: Windows](https://getsession.org/download)
         - [:simple-apple: macOS](https://getsession.org/download)
-        - [:simple-appstore: App Store](https://apps.apple.com/app/id1470168868)
         - [:simple-linux: Linux](https://getsession.org/download)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=network.loki.messenger)
-        - [:simple-fdroid: F-Droid](https://fdroid.getsession.org)
 
 Session allows for E2EE in one-on-one chats or closed groups which allow for up to 100 members. Open groups have no restriction on the number of members, but are open by design.
 
@@ -122,9 +123,8 @@ Session has a [whitepaper](https://arxiv.org/pdf/2002.04609.pdf) describing the 
 
     ??? downloads
 
-        - [:simple-flathub: Flatpak](https://flathub.org/apps/details/org.briarproject.Briar)
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.briarproject.briar.android)
-        - [:simple-fdroid: F-Droid](https://f-droid.org/packages/org.briarproject.briar.android)
+        - [:simple-flathub: Flathub](https://flathub.org/apps/details/org.briarproject.Briar)
 
 To add a contact on Briar, you must both add each other first. You can either exchange `briar://` links or scan a contact’s QR code if they are nearby.
 

--- a/docs/real-time-communication/signal-configuration-hardening.en.md
+++ b/docs/real-time-communication/signal-configuration-hardening.en.md
@@ -212,7 +212,6 @@ On Android you can consider using **Molly**, a fork of the Signal mobile client 
 
     ??? downloads
 
-         - [:simple-fdroid: F-Droid](https://molly.im/download/fdroid/)
          - [:simple-github: GitHub](https://github.com/mollyim/mollyim-android/releases)
 
 Molly offers two variants of the app: **Molly** and **Molly-FOSS**.

--- a/docs/tor.en.md
+++ b/docs/tor.en.md
@@ -43,15 +43,14 @@ There are a variety of ways to connect to the Tor network from your device, the 
 
     ??? downloads
 
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.torproject.torbrowser)
+        - [:simple-android: Android](https://www.torproject.org/download/#android)
         - [:simple-windows11: Windows](https://www.torproject.org/download/)
         - [:simple-apple: macOS](https://www.torproject.org/download/)
         - [:simple-linux: Linux](https://www.torproject.org/download/)
         - [:simple-freebsd: FreeBSD](https://www.freshports.org/security/tor)
         - [:simple-openbsd: OpenBSD](https://openports.se/net/tor)
         - [:simple-netbsd: NetBSD](https://pkgsrc.se/net/tor)
-        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.torproject.torbrowser)
-        - [:simple-fdroid: F-Droid](https://support.torproject.org/tormobile/tormobile-7/)
-        - [:simple-android: Android](https://www.torproject.org/download/#android)
 
 !!! danger
 
@@ -76,9 +75,8 @@ The Tor Browser is designed to prevent fingerprinting, or identifying you based 
     ??? downloads
 
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.torproject.android)
-        - [:simple-fdroid: F-Droid](https://guardianproject.info/fdroid)
-        - [:simple-github: GitHub](https://github.com/guardianproject/orbot/releases)
         - [:simple-appstore: App Store](https://apps.apple.com/us/app/orbot/id1609461599)
+        - [:simple-github: GitHub](https://github.com/guardianproject/orbot/releases)
 
 For resistance against traffic analysis attacks, consider enabling *Isolate Destination Address* in :material-menu: → **Settings** → **Connectivity**. This will use a completely different Tor Circuit (different middle relay and exit nodes) for every domain you connect to.
 

--- a/docs/vpn.en.md
+++ b/docs/vpn.en.md
@@ -40,6 +40,14 @@ Find a no-logging VPN operator who isn’t out to sell or read your web traffic.
     [:octicons-info-16:](https://protonvpn.com/support/){ .card-link title=Documentation}
     [:octicons-code-16:](https://github.com/ProtonVPN){ .card-link title="Source Code" }
 
+    ??? downloads
+
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=ch.protonvpn.android)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/apple-store/id1437005085)
+        - [:simple-github: GitHub](https://github.com/ProtonVPN/android-app/releases)
+        - [:simple-windows11: Windows](https://protonvpn.com/download-windows)
+        - [:simple-linux: Linux](https://protonvpn.com/support/linux-vpn-setup/)
+
 ??? check annotate "64 Countries"
 
     Proton VPN has [servers in 64 countries](https://protonvpn.com/vpn-servers) (1). Picking a VPN provider with a server nearest to you will reduce latency of the network traffic you send. This is because of a shorter route (fewer hops) to the destination.
@@ -90,6 +98,15 @@ Find a no-logging VPN operator who isn’t out to sell or read your web traffic.
     [:octicons-eye-16:](https://www.ivpn.net/privacy/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://www.ivpn.net/knowledgebase/general/){ .card-link title=Documentation}
     [:octicons-code-16:](https://github.com/ivpn){ .card-link title="Source Code" }
+
+    ??? downloads
+    
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=net.ivpn.client)
+        - [:simple-appstore: App Store](https://apps.apple.com/us/app/ivpn-serious-privacy-protection/id1193122683)
+        - [:simple-github: GitHub](https://github.com/ivpn/android-app/releases)
+        - [:simple-windows11: Windows](https://www.ivpn.net/apps-windows/)
+        - [:simple-apple: macOS](https://www.ivpn.net/apps-macos/)
+        - [:simple-linux: Linux](https://www.ivpn.net/apps-linux/)
 
 ??? check annotate "34 Countries"
 
@@ -142,6 +159,15 @@ Find a no-logging VPN operator who isn’t out to sell or read your web traffic.
     [:octicons-eye-16:](https://mullvad.net/en/help/privacy-policy/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://mullvad.net/en/help/){ .card-link title=Documentation}
     [:octicons-code-16:](https://github.com/mullvad){ .card-link title="Source Code" }
+
+    ??? downloads
+    
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=net.mullvad.mullvadvpn)
+        - [:simple-appstore: App Store](https://apps.apple.com/app/mullvad-vpn/id1488466513)
+        - [:simple-github: GitHub](https://github.com/mullvad/mullvadvpn-app/releases)
+        - [:simple-windows11: Windows](https://mullvad.net/en/download/windows/)
+        - [:simple-apple: macOS](https://mullvad.net/en/download/macos/)
+        - [:simple-linux: Linux](https://mullvad.net/en/download/linux/)
 
 ??? check annotate "39 Countries"
 


### PR DESCRIPTION
# Resolves #1727

## Standardized Order

|Download Type|Format|Details|
|---|---|---|
|Google Play Store|`[:simple-googleplay: Google Play]()`||
|App Store|`[:simple-appstore: App Store]()`|iOS, macOS, and iPadOS|
|GitHub, etc.|`[:simple-ICON: NAME]()`|Provided that they have a "Releases" section—with downloads—like GitLab and Codeberg|
|Windows|`[:simple-windows11: Windows]()`|.exe files|
|macOS|`[:simple-apple: macOS]()`|.dmg or .pkg files|
|Linux|`[:simple-linux: Linux]()`|.deb, .rpm, etc. *or* distribution-specific instructions|
|PWAs or Extensions|`[:octicons-globe-16: PWA]()` `[:simple-ICON: NAME]()`|Use the browser name. Order: Firefox, Chrome, Edge, Safari|
|Web|`[:octicons-browser-16: Web]()`|e.g. [Snowflake](https://www.privacyguides.org/tor/#snowflake)|
|FreeBSD|`[:simple-freebsd: FreeBSD]()`||
|OpenBSD|`[:simple-openbsd: OpenBSD]()`||
|NetBSD|`[:simple-netbsd: NetBSD]()`||

## Notes

### APKs

#### Official Website

- [Cryptomator](https://cryptomator.org/android) (Edit: auto-updates).
- [Signal](https://signal.org/android/apk/) (auto-updates).
- [Tor](https://www.torproject.org/download/#android) (unsure). :warning: For Review

#### GitHub+, added:

- [BitWarden](https://github.com/bitwarden/mobile/releases)
- [Brave](https://github.com/brave/brave-browser/releases)
- [Element](https://github.com/vector-im/element-android/releases)
- [FairEmail](https://github.com/M66B/FairEmail/releases)
- [Joplin](https://github.com/laurent22/joplin-android/releases)
- [Nextcloud](https://github.com/nextcloud/android/releases)
- [RethinkDNS](https://github.com/celzero/rethink-app/releases)
- [Session](https://github.com/oxen-io/session-android/releases)

### Flathub :warning: For Review

`Live?` Is the Flathub download currently listed on privacyguides.org?

|Name|Live?|Official?|Details|
|---|---|---|---|
|[1Password](https://support.1password.com/install-linux/#flatpak)|:red_circle:|:green_circle:|[Official Flatpak image](https://support.1password.com/install-linux/#flatpak), direct from 1password.com (not on Flathub)|
|[Akregator](https://flathub.org/apps/details/org.kde.akregator)|:green_circle:|:question:|Linked on homepage|
|[BitWarden](https://flathub.org/apps/details/com.bitwarden.desktop)|:green_circle:|:question:|Not linked on homepage|
|[Brave](https://flathub.org/apps/details/com.brave.Browser)|:red_circle:|:orange_circle:|[Linked](https://brave.com/linux/#release-channel-installation) as an unofficial image|
|[Briar](https://flathub.org/apps/details/org.briarproject.Briar)|:green_circle:|:question:|Not linked on homepage|
|[Cryptomator](https://flathub.org/apps/details/org.cryptomator.Cryptomator)|:green_circle:|:question:|Linked on homepage|
|[Element](https://flathub.org/apps/details/im.riot.Riot)|:red_circle:|:question:|Linked on homepage|
|[Evolution](https://wiki.gnome.org/Apps/Evolution/Flatpak)|:green_circle:|:question:|Linked on homepage ([support article](https://wiki.gnome.org/Apps/Evolution/Flatpak))|
|[Firefox](https://flathub.org/apps/details/org.mozilla.firefox)|:green_circle:|:question:|Linked in [support article](https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-from-flatpak)|
|[FreeTube](https://flathub.org/apps/details/io.freetubeapp.FreeTube)|:green_circle:|:question:|Same primary contributor ([FreeTube](https://github.com/FreeTubeApp/FreeTube/graphs/contributors) vs. [Flathub](https://github.com/flathub/io.freetubeapp.FreeTube/graphs/contributors/))
|[GNOME Feeds](https://flathub.org/apps/details/org.gabmus.gfeeds)|:green_circle:|:question:|Linked on homepage|
|[Joplin](https://flathub.org/apps/details/net.cozic.joplin_desktop)|:red_circle:|:orange_circle:|[Linked](https://discourse.joplinapp.org/t/unofficial-alternative-joplin-distributions/23703) as an unofficial image|
|[KeePassXC](https://flathub.org/apps/details/org.keepassxc.KeePassXC)|:green_circle:|:green_circle:|[Official](https://keepassxc.org/download/#linux) download|
|[LBRY](https://flathub.org/apps/details/io.lbry.lbry-app)|:red_circle:|:orange_circle:|[Listed](https://github.com/lbryio/lbry-desktop#install) as unofficial image|
|[LibreOffice](https://flathub.org/apps/details/org.libreoffice.LibreOffice)|:green_circle:|:question:|Linked on homepage|
|[Nextcloud](https://flathub.org/apps/details/com.nextcloud.desktopclient.nextcloud)|:red_circle:|:question:|Not linked on homepage|
|[OnlyOffice](https://flathub.org/apps/details/org.onlyoffice.desktopeditors)|:green_circle:|:green_circle:|[Official](https://www.onlyoffice.com/download-desktop.aspx) download|
|[OnionShare](https://flathub.org/apps/details/org.onionshare.OnionShare)|:red_circle:|:green_circle:|Recommended [download](https://docs.onionshare.org/2.5/en/install.html#install-in-linux)|
|[Session](https://flathub.org/apps/details/network.loki.Session)|:red_circle:|:orange_circle:|[GitHub issue](https://github.com/oxen-io/session-desktop/issues/2146)|
|[Signal](https://flathub.org/apps/details/org.signal.Signal)|:green_circle:|:question:|Not linked on homepage|
|[Standard Notes](https://flathub.org/apps/details/org.standardnotes.standardnotes)|:orange_circle:|:question:|Not linked on homepage|
|[Syncthing GTK](https://flathub.org/apps/details/me.kozec.syncthingtk) and [SyncThingy](https://flathub.org/apps/details/com.github.zocker_160.SyncThingy)|:red_circle:|:orange_circle:|Not linked on homepage|
|[Thunderbird](https://flathub.org/apps/details/org.mozilla.Thunderbird)|:green_circle:|:question:|Not linked on homepage|
|[Tor Browser Launcher](https://flathub.org/apps/details/com.github.micahflee.torbrowser-launcher)|:red_circle:|:question:|[GitHub](https://github.com/micahflee/torbrowser-launcher) not recently updated? [Security Design](https://github.com/micahflee/torbrowser-launcher/blob/develop/security_design.md)|
|[Tutanota](https://flathub.org/apps/details/com.tutanota.Tutanota)|:green_circle:|:question:|Not linked on homepage|

### Docker Hub :warning: For Review
- Included Docker Hub links for tools which already had them. There might be more tools where it makes sense to link to Docker Hub.
    - [EteSync](https://hub.docker.com/r/victorrds/etesync)
    - [Psono](https://hub.docker.com/r/psono/psono-client)

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you MUST disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] Please check this box to confirm you have disclosed any relevant conflicts of interest in your post.
- [x] Please check this box to confirm your agreement to publish your work under the [Creative Commons Attribution-NoDerivatives 4.0 International](https://github.com/privacyguides/privacyguides.org/blob/main/LICENSE) license, and to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform and distribute your contribution as part of our project.

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
