### PR TITLE
Fix search suggestions

### DIFF
--- a/docs/desktop-browsers.en.md
+++ b/docs/desktop-browsers.en.md
@@ -50,9 +50,7 @@ This protects you from persistent cookies, but does not protect you against cook
 
 ##### Search Suggestions
 
-- [ ] Disable **Suggestions from the web**
-- [ ] Disable **Suggestions from sponsors**
-- [ ] Disable **Improve the Firefox Suggest experience**
+- [ ] Uncheck **Provide search suggestions**
 
 Search suggestion features may not be available in your region.
 


### PR DESCRIPTION
Firefox Suggest doesn't send data but [search suggestions](https://support.mozilla.org/en-US/kb/search-suggestions-firefox) does. I went ahead and fixed this.