### PR TITLE
Other uBO lists

### DIFF
--- a/docs/desktop-browsers.en.md
+++ b/docs/desktop-browsers.en.md
@@ -207,4 +207,11 @@ We generally do not recommend installing any extensions as they increase your at
         - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)
         - [:simple-microsoftedge: Edge](https://microsoftedge.microsoft.com/addons/detail/ublock-origin/odfafepnkmbhccpbejgmiehpchacaeak)
 
-We suggest following the [developer's documentation](https://github.com/gorhill/uBlock/wiki/Blocking-mode) and picking one of the "modes". Additional filter lists can impact performance and may increase attack surface, so only apply what you need. If there is a [vulnerability in uBlock Origin](https://portswigger.net/research/ublock-i-exfiltrate-exploiting-ad-blockers-with-css) a third-party filter could add malicious rules that can potentially steal user data.
+We suggest following the [developer's documentation](https://github.com/gorhill/uBlock/wiki/Blocking-mode) and picking one of the "modes". Additional filter lists can impact performance and [may increase attack surface](https://portswigger.net/research/ublock-i-exfiltrate-exploiting-ad-blockers-with-css).
+
+##### Other lists
+
+These are some other [filter lists](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists) that you may want to consider adding:
+
+- [x] Check **Privacy** > **AdGuard URL Tracking Protection**
+- Add [Actually Legitimate URL Shortener Tool](https://raw.githubusercontent.com/DandelionSprout/adfilt/master/LegitimateURLShortener.txt)


### PR DESCRIPTION
I reworded the description to sound a bit better.

It seems that `AdGuard URL Tracking Protection` and `Actually Legitimate URL Shortener Tool` were removed, https://github.com/privacyguides/privacyguides.org/pull/1238/files and these are pretty harmless. This makes our recommendations compatible with https://github.com/arkenfox/user.js/wiki/4.1-Extensions#-recommended which I think is quite reasonable.

Also came up in https://github.com/privacyguides/privacyguides.org/discussions/1328