### PR TITLE
Clarify PGP on Apple Mail

### DIFF
--- a/docs/email-clients.en.md
+++ b/docs/email-clients.en.md
@@ -60,7 +60,7 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
     ![Apple Mail logo](assets/img/email-clients/applemail.png){ align=right }
 
-    **Apple Mail** is included in macOS and can be extended to have OpenPGP support with [GPG Suite](encryption.md#gpg-suite), which adds the ability to send encrypted email.
+    **Apple Mail** is included in macOS and can be extended to have OpenPGP support with [GPG Suite](encryption.md#gpg-suite), which adds the ability to send PGP-encrypted email.
 
     [:octicons-home-16: Homepage](https://support.apple.com/guide/mail/welcome/mac){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }


### PR DESCRIPTION
Added PGP-encrypted since by default Apple Mail supports S/MIME.
<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

Please share with us what you've changed.
If you are adding a software recommendation, give us a link to its website or
source code.

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.

That someone has a conflict of interest is a description of a situation,
NOT a judgement about that person's opinions, integrity, or good faith.

If you have a conflict of interest, you MUST disclose who is paying you for
this contribution, who the client is (if for example, you are being paid by
an advertising agency), and any other relevant affiliations.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] Please check this box to confirm you have disclosed any relevant conflicts of interest in your post.
- [x] Please check this box to confirm your agreement to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute your contribution as part of our project.
- [x] Please check this box to confirm you are the sole author of this work, or that any additional authors will also reply to this PR on GitHub confirming their agreement to these terms.

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
