### PR TITLE
Add breadcrumb metadata

### DIFF
--- a/theme/partials/path-item.html
+++ b/theme/partials/path-item.html
@@ -1,0 +1,20 @@
+{% macro render(nav_item, ref = nav_item) %}
+  {% if nav_item.children %}
+    {% set first = nav_item.children | first %}
+    {% if first.children %}
+      {{ render(first, ref) }}
+    {% else %}
+      <a href="{{ first.canonical_url | url }}" class="md-path__link" property="item" typeof="WebPage">
+        <span class="md-ellipsis" property="name">
+          {{ ref.title }}
+        </span>
+      </a>
+    {% endif %}
+  {% else %}
+    <a href="{{ nav_item.canonical_url | url }}" class="md-path__link" property="item" typeof="WebPage">
+      <span class="md-ellipsis" property="name">
+        {{ ref.title }}
+      </span>
+    </a>
+  {% endif %}
+{% endmacro %}

--- a/theme/partials/path.html
+++ b/theme/partials/path.html
@@ -1,0 +1,33 @@
+{% import "partials/path-item.html" as item with context %}
+{% if page.meta and page.meta.hide %}
+  {% set hidden = "hidden" if "path" in page.meta.hide %}
+{% endif %}
+{% set depth = page.ancestors | length %}
+{% if nav.homepage %}
+  {% set depth = depth + 1 %}
+{% endif %}
+{% if depth > 1 %}
+  {% set count = namespace(value=1) %}
+  <nav class="md-path" aria-label="{{ lang.t('nav') }}" {{ hidden }}>
+    <ol class="md-path__list" vocab="https://schema.org/" typeof="BreadcrumbList">
+      {% if nav.homepage %}
+        <li class="md-path__item" property="itemListElement" typeof="ListItem">
+          {{ item.render(nav.homepage) }}
+          <meta property="position" content="{{ count.value }}">
+          {% set count.value = count.value + 1 %}
+        </li>
+      {% endif %}
+      {% for nav_item in page.ancestors | reverse %}
+        <li class="md-path__item" property="itemListElement" typeof="ListItem">
+          {{ item.render(nav_item) }}
+          <meta property="position" content="{{ count.value }}">
+          {% set count.value = count.value + 1 %}
+        </li>
+      {% endfor %}
+      <li property="itemListElement" typeof="ListItem" hidden>
+        <meta property="name" content="{{ page.title }}">
+        <meta property="position" content="{{ count.value }}">
+      </li>
+    </ol>
+  </nav>
+{% endif %}


### PR DESCRIPTION
This adds `BreadcrumbList` metadata to the breadcrumbs on the site since they won't be added upstream: https://github.com/squidfunk/mkdocs-material/issues/5091

https://developers.google.com/search/docs/appearance/structured-data/breadcrumb

test with https://search.google.com/test/rich-results