### PR TITLE
Remove notice that the protondrive app is not opensource.

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -28,7 +28,6 @@ If these alternatives do not fit your needs, we suggest you look into [Encryptio
         - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=me.proton.android.drive)
         - [:simple-appstore: App Store](https://apps.apple.com/app/id1509667851)
 
-Proton Drive's mobile clients were released in December 2022 and are not yet open-source. Proton has historically delayed their source code releases until after initial product releases, and [plans to](https://www.reddit.com/r/ProtonDrive/comments/zf14i8/comment/izdwmme/?utm_source=share&utm_medium=web2x&context=3) release the source code by the end of 2023. Proton Drive desktop clients are still in development.
 
 ## Criteria
 


### PR DESCRIPTION
Protonmail has released the source code for their apps on march second. This removes the notice that its closed source.



- [x] Please check this box to confirm you have disclosed any relevant conflicts of interest in your post.
- [x] Please check this box to confirm your agreement to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute your contribution as part of our project.
- [x] Please check this box to confirm you are the sole author of this work, or that any additional authors will also reply to this PR on GitHub confirming their agreement to these terms.