### PR TITLE
Remove UK from CoinCards countries

### DIFF
--- a/Brewfile.preview.netlify
+++ b/Brewfile.preview.netlify
@@ -1,0 +1,1 @@
+brew "pngquant"

--- a/docs/financial-services.md
+++ b/docs/financial-services.md
@@ -76,7 +76,7 @@ These services allow you to purchase gift cards for a variety of merchants onlin
 
     ![CakePay logo](assets/img/financial-services/coincards.svg){ align=right }
 
-    **CoinCards** (available in the US, Canada, and UK) allows you to purchase gift cards for a large variety of merchants.
+    **CoinCards** (available in the US and Canada) allows you to purchase gift cards for a large variety of merchants.
 
     [:octicons-home-16: Homepage](https://coincards.com/){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://coincards.com/privacy-policy/){ .card-link title="Privacy Policy" }

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,9 @@
     publish = "site/"
     command = "crowdin download && mkdocs build --config-file config/mkdocs.en.yml && mkdocs build --config-file config/mkdocs.es.yml && mkdocs build --config-file config/mkdocs.he.yml && mkdocs build --config-file config/mkdocs.fr.yml && mkdocs build --config-file config/mkdocs.nl.yml && mv _redirects site/"
 
+    [context.deploy-preview]
+        command = "mkdocs build --config-file config/mkdocs.en.yml && mv _redirects site/"
+
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
Closes #2116 

Changes proposed in this PR:

- CoinCards doesn't seem to provide service in the UK just yet: https://coincards.com/uk/

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
