### PR TITLE
Add Accrescent & Play Store Link For IVPN

### DIFF
--- a/docs/vpn.md
+++ b/docs/vpn.md
@@ -47,7 +47,8 @@ Our recommended providers use encryption, accept Monero, support WireGuard & Ope
 
     ??? downloads
     
-        - [:simple-android: Android](https://www.ivpn.net/apps-android/)
+        - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=net.ivpn.client)
+        - [:octicons-moon-16: Accrescent](https://accrescent.app/app/net.ivpn.client)
         - [:simple-appstore: App Store](https://apps.apple.com/app/ivpn-serious-privacy-protection/id1193122683)
         - [:simple-windows11: Windows](https://www.ivpn.net/apps-windows/)
         - [:simple-apple: macOS](https://www.ivpn.net/apps-macos/)


### PR DESCRIPTION
Changes proposed in this PR:

This PR replaces https://www.ivpn.net/apps-android/ link with direct Play Store and Accrescent download links. Direct Play Store link was chosen for consistency with other entries across the site, and Accrescent was added as IVPN made it onto the store.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
