### PR TITLE
Add mention of Apple Mail's Protect Mail Activity feature

### DIFF
--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -57,7 +57,7 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
 ## Platform Specific
 
-### Apple Mail (macOS, iOS)
+### Apple Mail (macOS)
 
 !!! recommendation
 

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -69,7 +69,7 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
     [:octicons-home-16: Homepage](https://support.apple.com/guide/mail/welcome/mac){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }
-    [:octicons-info-16:](https://support.apple.com/guide/mail/toc){ .card-link title=Documentation}
+    [:octicons-info-16:](https://support.apple.com/mail){ .card-link title=Documentation}
 
 ### Canary Mail (iOS)
 

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -65,7 +65,7 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
     **Apple Mail** is included in macOS and can be extended to have OpenPGP support with [GPG Suite](encryption.md#gpg-suite), which adds the ability to send PGP-encrypted email.
 
-    It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders on [macOS](https://support.apple.com/guide/mail/use-mail-privacy-protection-mlhl03be2866/mac#:~:text=In%20the%20Mail%20app%20on,of%20when%20you%20view%20it) and [iOS](https://support.apple.com/guide/iphone/use-mail-privacy-protection-iphf084865c7/ios).
+    It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders on [macOS](https://support.apple.com/guide/mail/mlhl03be2866/mac) and [iOS](https://support.apple.com/guide/iphone/iphf084865c7/ios).
 
     [:octicons-home-16: Homepage](https://support.apple.com/guide/mail/welcome/mac){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -69,6 +69,10 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.apple.com/guide/mail/toc){ .card-link title=Documentation}
 
+It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders. Under Mail > Settings > Privacy
+
+[x] Check **Protect Mail Activity**
+
 ### Canary Mail (iOS)
 
 !!! recommendation

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -69,9 +69,9 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.apple.com/guide/mail/toc){ .card-link title=Documentation}
 
-It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders. Under Mail > Settings > Privacy
+It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders. Under Mail → Settings → Privacy
 
-[x] Check **Protect Mail Activity**
+- [x] Check **Protect Mail Activity**
 
 ### Canary Mail (iOS)
 

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -57,7 +57,7 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
 ## Platform Specific
 
-### Apple Mail (macOS)
+### Apple Mail (macOS, iOS)
 
 !!! recommendation
 
@@ -65,13 +65,11 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
     **Apple Mail** is included in macOS and can be extended to have OpenPGP support with [GPG Suite](encryption.md#gpg-suite), which adds the ability to send PGP-encrypted email.
 
+    It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders on [macOS](https://support.apple.com/guide/mail/use-mail-privacy-protection-mlhl03be2866/mac#:~:text=In%20the%20Mail%20app%20on,of%20when%20you%20view%20it) and [iOS](https://support.apple.com/guide/iphone/use-mail-privacy-protection-iphf084865c7/ios).
+
     [:octicons-home-16: Homepage](https://support.apple.com/guide/mail/welcome/mac){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.apple.com/guide/mail/toc){ .card-link title=Documentation}
-
-It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders. Under **Mail** → **Settings** → **Privacy**
-
-- [x] Check **Protect Mail Activity**
 
 ### Canary Mail (iOS)
 

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -65,11 +65,11 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 
     **Apple Mail** is included in macOS and can be extended to have OpenPGP support with [GPG Suite](encryption.md#gpg-suite), which adds the ability to send PGP-encrypted email.
 
-    It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders on [macOS](https://support.apple.com/guide/mail/mlhl03be2866/mac) and [iOS](https://support.apple.com/guide/iphone/iphf084865c7/ios).
-
     [:octicons-home-16: Homepage](https://support.apple.com/guide/mail/welcome/mac){ .md-button .md-button--primary }
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.apple.com/mail){ .card-link title=Documentation}
+
+Apple Mail has the ability to load remote content in the background or block it entirely and hide your IP address from senders on [macOS](https://support.apple.com/guide/mail/mlhl03be2866/mac) and [iOS](https://support.apple.com/guide/iphone/iphf084865c7/ios).
 
 ### Canary Mail (iOS)
 

--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -69,7 +69,7 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
     [:octicons-eye-16:](https://www.apple.com/legal/privacy/en-ww/){ .card-link title="Privacy Policy" }
     [:octicons-info-16:](https://support.apple.com/guide/mail/toc){ .card-link title=Documentation}
 
-It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders. Under Mail → Settings → Privacy
+It also features the ability to load remote content in the background or block it entirely and hide your IP address from senders. Under **Mail** → **Settings** → **Privacy**
 
 - [x] Check **Protect Mail Activity**
 


### PR DESCRIPTION
Changes proposed in this PR:

- Adds the Protect Mail Activity setting to Apple Mail

closes #2014 
<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
