### PR TITLE
Enable Chinese Traditional Translation

### DIFF
--- a/config/layouts/custom.yml
+++ b/config/layouts/custom.yml
@@ -21,8 +21,12 @@ definitions:
     {{ layout.color or "#2d2d2d" }}
 
   - &title_font_family >-
-    {%- if config.theme.language == "he" -%}
+    {%- if page.is_homepage -%}
+      Bagnard
+    {%- elif config.theme.language == "he" -%}
       Suez One
+    {%- elif config.theme.language == "zh-Hant" -%}
+      Noto Serif TC
     {%- else -%}
       Bagnard
     {%- endif -%}
@@ -30,6 +34,8 @@ definitions:
   - &font_family >-
     {%- if config.theme.language == "he" -%}
       Suez One
+    {%- elif config.theme.language == "zh-Hant" -%}
+      Noto Sans TC
     {%- else -%}
       Public Sans
     {%- endif -%}
@@ -64,7 +70,7 @@ definitions:
   
   - &homepage_description >-
     {%- if page.is_homepage -%}
-      A socially motivated website which provides information about protecting your online data privacy and security.
+      {{ config.extra.homepage_description or "A socially motivated website which provides information about protecting your online data privacy and security." }}
     {%- else -%}
     {%- endif -%}
 

--- a/config/mkdocs-common.yml
+++ b/config/mkdocs-common.yml
@@ -62,6 +62,10 @@ extra:
       link: /nl/
       lang: nl
       icon: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f1f3-1f1f1.svg
+    - name: 正體中文
+      link: /zh-hant/
+      lang: zh-Hant
+      icon: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f1ed-1f1f0.svg
 
 repo_url: https://github.com/privacyguides/privacyguides.org
 repo_name: ""

--- a/config/mkdocs.zh-Hant.yml
+++ b/config/mkdocs.zh-Hant.yml
@@ -1,0 +1,164 @@
+# Copyright (c) 2022-2023 Jonah Aragon <jonah@triplebit.net>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+INHERIT: mkdocs-common.yml
+docs_dir: '../i18n/zh-Hant'
+site_url: "https://www.privacyguides.org/zh-hant/"
+site_dir: '../site/zh-hant'
+
+site_name: Privacy Guides
+site_description: |
+  Privacy Guides 是您重要的網路隱私與安全資源。
+copyright: |
+  <b>Privacy Guides</b> 是一個非營利、社會導向的網站，旨在提供有關資訊以確保您的資料安全和隱私。</br>
+   我們不會通過推薦某些產品來賺錢，我們也不會使用推廣回贈鏈接。
+  &copy; 2019 - 2023 Privacy Guides 和貢獻者。
+  <span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><!--! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="m245.83 214.87-33.22 17.28c-9.43-19.58-25.24-19.93-27.46-19.93-22.13 0-33.22 14.61-33.22 43.84 0 23.57 9.21 43.84 33.22 43.84 14.47 0 24.65-7.09 30.57-21.26l30.55 15.5c-6.17 11.51-25.69 38.98-65.1 38.98-22.6 0-73.96-10.32-73.96-77.05 0-58.69 43-77.06 72.63-77.06 30.72-.01 52.7 11.95 65.99 35.86zm143.05 0-32.78 17.28c-9.5-19.77-25.72-19.93-27.9-19.93-22.14 0-33.22 14.61-33.22 43.84 0 23.55 9.23 43.84 33.22 43.84 14.45 0 24.65-7.09 30.54-21.26l31 15.5c-2.1 3.75-21.39 38.98-65.09 38.98-22.69 0-73.96-9.87-73.96-77.05 0-58.67 42.97-77.06 72.63-77.06 30.71-.01 52.58 11.95 65.56 35.86zM247.56 8.05C104.74 8.05 0 123.11 0 256.05c0 138.49 113.6 248 247.56 248 129.93 0 248.44-100.87 248.44-248 0-137.87-106.62-248-248.44-248zm.87 450.81c-112.54 0-203.7-93.04-203.7-202.81 0-105.42 85.43-203.27 203.72-203.27 112.53 0 202.82 89.46 202.82 203.26-.01 121.69-99.68 202.82-202.84 202.82z"></path></svg></span><span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><!--! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M314.9 194.4v101.4h-28.3v120.5h-77.1V295.9h-28.3V194.4c0-4.4 1.6-8.2 4.6-11.3 3.1-3.1 6.9-4.7 11.3-4.7H299c4.1 0 7.8 1.6 11.1 4.7 3.1 3.2 4.8 6.9 4.8 11.3zm-101.5-63.7c0-23.3 11.5-35 34.5-35s34.5 11.7 34.5 35c0 23-11.5 34.5-34.5 34.5s-34.5-11.5-34.5-34.5zM247.6 8C389.4 8 496 118.1 496 256c0 147.1-118.5 248-248.4 248C113.6 504 0 394.5 0 256 0 123.1 104.7 8 247.6 8zm.8 44.7C130.2 52.7 44.7 150.6 44.7 256c0 109.8 91.2 202.8 203.7 202.8 103.2 0 202.8-81.1 202.8-202.8.1-113.8-90.2-203.3-202.8-203.3z"></path></svg></span><span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><!--! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M247.6 8C389.4 8 496 118.1 496 256c0 147.1-118.5 248-248.4 248C113.6 504 0 394.5 0 256 0 123.1 104.7 8 247.6 8zm.8 44.7C130.2 52.7 44.7 150.6 44.7 256c0 109.8 91.2 202.8 203.7 202.8 103.2 0 202.8-81.1 202.8-202.8.1-113.8-90.2-203.3-202.8-203.3zm94 144.3v42.5H162.1V197h180.3zm0 79.8v42.5H162.1v-42.5h180.3z"></path></svg></span>
+   根據CC BY-ND 4.0授權的內容。 <a href="/license"><strong>CC BY-ND 4.0</strong></a>.
+edit_uri: edit/main/i18n/zh-Hant/
+
+extra:
+  generator: false
+  analytics:
+    provider: plausible
+    property: privacyguides.org
+    feedback:
+      title: "這個頁面對您有幫助嗎？"
+      ratings:
+        - icon: material/robot-happy-outline
+          name: "此頁有幫助"
+          data: Helpful
+          note: "感謝反饋!"
+        - icon: material/robot-confused
+          name: "此頁面可以改善"
+          data: Needs Improvement
+          note: "感謝你的意見！通過在的論壇上開啟<a href='https://discuss.privacyguides.net'>討論來協助我們改善此頁面。</a>"
+
+extra_css:
+  - assets/stylesheets/extra.css?v=3.2.0
+  - assets/stylesheets/lang-zh-Hant.css?v=3.13.0
+
+theme:
+  language: zh-Hant
+  font:
+    text: Noto Sans TC
+    code: Noto Sans TC
+  palette:
+    - media: "(prefers-color-scheme)"
+      scheme: default
+      accent: deep purple
+      toggle:
+        icon: material/brightness-auto
+        name: "切換至深色模式"
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      accent: amber
+      toggle:
+        icon: material/brightness-2
+        name: "切換至淺色模式"
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      accent: deep purple
+      toggle:
+        icon: material/brightness-5
+        name: "切換到系統主題"
+
+markdown_extensions:
+  pymdownx.snippets:
+    auto_append: 
+      - includes/abbreviations.zh-Hant.txt
+
+nav:
+  - 首頁: 'index.md'
+  - 知識庫:
+    - 'basics/why-privacy-matters.md'
+    - 'basics/threat-modeling.md'
+    - 'basics/common-threats.md'
+    - 'basics/common-misconceptions.md'
+    - 'basics/account-creation.md'
+    - 'basics/account-deletion.md'
+    - 技術精華:
+      - 'basics/passwords-overview.md'
+      - 'basics/multi-factor-authentication.md'
+      - 'basics/email-security.md'
+      - 'basics/vpn-overview.md'
+    - 進階主題:
+      - 'advanced/dns-overview.md'
+      - 'advanced/tor-overview.md'
+      - 'advanced/payments.md'
+      - 'advanced/communication-network-types.md'
+    - 作業系統:
+      - 'os/android-overview.md'
+      - 'os/linux-overview.md'
+      - 'os/qubes-overview.md'
+    - kb-archive.md
+  - 推薦:
+    - 'tools.md'
+    - 網際網路瀏覽:
+      - 'tor.md'
+      - 'desktop-browsers.md'
+      - 'mobile-browsers.md'
+    - 提供者:
+      - 'cloud.md'
+      - 'dns.md'
+      - 'email.md'
+      - 'financial-services.md'
+      - 'search-engines.md'
+      - 'vpn.md'
+    - 軟體:
+      - 'calendar.md'
+      - 'cryptocurrency.md'
+      - 'data-redaction.md'
+      - 'email-clients.md'
+      - 'encryption.md'
+      - 'file-sharing.md'
+      - 'frontends.md'
+      - 'multi-factor-authentication.md'
+      - 'news-aggregators.md'
+      - 'notebooks.md'
+      - 'passwords.md'
+      - 'productivity.md'
+      - 'real-time-communication.md'
+      - 'video-streaming.md'
+    - 作業系統:
+      - 'android.md'
+      - 'desktop.md'
+      - 'router.md'
+  - 關於:
+    - 'about/index.md'
+    - 'about/criteria.md'
+    - 'about/statistics.md'
+    - 'about/notices.md'
+    - 'about/privacy-policy.md'
+    - 社群:
+      - 'about/donate.md'
+      - 線上服務: 'about/services.md'
+      - 行為守則: 'CODE_OF_CONDUCT.md'
+      - 'about/privacytools.md'
+    - 貢獻:
+      - 寫作指南:
+        - 'meta/writing-style.md'
+        - 'meta/brand.md'
+      - 技術指導:
+        - 'meta/uploading-images.md'
+        - 'meta/git-recommendations.md'
+  - 變更記錄: 'https://github.com/privacyguides/privacyguides.org/releases'
+  - 論壇: 'https://discuss.privacyguides.net/'
+  - 部落格: 'https://blog.privacyguides.org/'

--- a/includes/strings.en.yml
+++ b/includes/strings.en.yml
@@ -45,5 +45,7 @@ nav:
   Blog: Blog
 
 site:
+  homepage_card: |
+    A socially motivated website which provides information about protecting your online data privacy and security.
   translation: |
     You're viewing the English copy of Privacy Guides, translated by our fantastic language team on Crowdin. If you notice an error, or see any untranslated sections on this page, please consider helping out! For more information and tips see our translation guide.

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,10 +23,10 @@
     command = "mkdocs build --config-file config/mkdocs.en.yml && cp -r static/* site/"
 
     [context.production]
-        command = "crowdin download && mkdocs build --config-file config/mkdocs.en.yml && mkdocs build --config-file config/mkdocs.es.yml && mkdocs build --config-file config/mkdocs.fr.yml && mkdocs build --config-file config/mkdocs.he.yml && mkdocs build --config-file config/mkdocs.it.yml && mkdocs build --config-file config/mkdocs.nl.yml && cp -r static/* site/"
+        command = "git clone https://github.com/privacyguides/i18n i18n-download && cp -rl i18n-download/i18n . && cp -rl i18n-download/includes . && cp -rl i18n-download/theme . && mkdocs build --config-file config/mkdocs.en.yml && mkdocs build --config-file config/mkdocs.es.yml && mkdocs build --config-file config/mkdocs.fr.yml && mkdocs build --config-file config/mkdocs.he.yml && mkdocs build --config-file config/mkdocs.it.yml && mkdocs build --config-file config/mkdocs.nl.yml && mkdocs build --config-file config/mkdocs.zh-Hant.yml && cp -r static/* site/"
 
     [context.branch-deploy]
-        command = "git clone https://github.com/privacyguides/i18n i18n-download && cp -rl i18n-download/i18n . && cp -rl i18n-download/includes . && cp -rl i18n-download/theme . && for i in config/mkdocs.*.yml; do mkdocs build --config-file $i; done && cp -r static/* site/"
+        command = "crowdin download && for i in config/mkdocs.*.yml; do mkdocs build --config-file $i; done && cp -r static/* site/"
         
 
 [[headers]]
@@ -71,6 +71,11 @@
 [[redirects]]
     from = "/nl/*"
     to = "/i18n/404.nl.html"
+    status = 404
+
+[[redirects]]
+    from = "/zh-hant/*"
+    to = "/i18n/404.zh-Hant.html"
     status = 404
 
 [[redirects]]

--- a/static/_redirects
+++ b/static/_redirects
@@ -18,13 +18,14 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-/  /en/  302  Language=en
-/  /es/  302  Language=es
-/  /fr/  302  Language=fr
-/  /he/  302  Language=he
-/  /it/  302  Language=it
-/  /nl/  302  Language=nl
-/  /en/  302
+/  /en/       302  Language=en
+/  /es/       302  Language=es
+/  /fr/       302  Language=fr
+/  /he/       302  Language=he
+/  /it/       302  Language=it
+/  /nl/       302  Language=nl
+/  /zh-hant/  302  Language=zh-Hant
+/  /en/       302
 
 /.well-known/matrix/* https://matrix.privacyguides.org/.well-known/matrix/:splat 200
 /.well-known/* /well-known/:splat 200

--- a/theme/assets/stylesheets/lang-zh-Hant.css
+++ b/theme/assets/stylesheets/lang-zh-Hant.css
@@ -1,0 +1,58 @@
+/*
+/// Copyright (c) 2023 Jonah Aragon <jonah@triplebit.net>
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a
+/// copy of this software and associated documentation files (the "Software"),
+/// to deal in the Software without restriction, including without limitation
+/// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+/// and/or sell copies of the Software, and to permit persons to whom the
+/// Software is furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+/// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+/// DEALINGS
+*/
+
+/* chinese-traditional */
+@font-face {
+  font-family: 'Noto Serif TC';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-chinese-traditional-400-normal.woff2) format('woff2'), url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-chinese-traditional-400-normal.woff) format('woff'); 
+}
+
+/* latin */
+@font-face {
+  font-family: 'Noto Serif TC';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-latin-400-normal.woff2) format('woff2'), url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-latin-400-normal.woff) format('woff'); 
+}
+
+/* chinese-traditional */
+@font-face {
+  font-family: 'Noto Serif TC';
+  font-style: normal;
+  font-weight: 700;
+  src: url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-chinese-traditional-700-normal.woff2) format('woff2'), url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-chinese-traditional-700-normal.woff) format('woff'); 
+}
+
+/* latin */
+@font-face {
+  font-family: 'Noto Serif TC';
+  font-style: normal;
+  font-weight: 700;
+  src: url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-latin-700-normal.woff2) format('woff2'), url(https://fonts.bunny.net/noto-serif-tc/files/noto-serif-tc-latin-700-normal.woff) format('woff'); 
+}
+
+h1, h2, h3, .md-header__topic {
+  font-family: "Bagnard", "Noto Serif TC", serif;
+  font-weight: 700!important;
+}

--- a/theme/main.html
+++ b/theme/main.html
@@ -139,5 +139,10 @@
     <p>Je bekijkt de Nederlandse versie van Privacy Guides, vertaald door ons fantastische taalteam op <a href="https://crowdin.com/project/privacyguides">Crowdin</a>. Als u een fout opmerkt of onvertaalde gedeelten op deze pagina ziet, <a href="https://matrix.to/#/#pg-i18n:aragon.sh">overweeg dan om te helpen</a>! Voor meer informatie en tips zie onze <a href="/meta/translation.md">vertaalgids</a>.</p>
     <p>You're viewing the Dutch copy of Privacy Guides, translated by our fantastic language team on <a href="https://crowdin.com/project/privacyguides">Crowdin</a>. If you notice an error, or see any untranslated sections on this page, please consider <a href="https://matrix.to/#/#pg-i18n:aragon.sh">helping out</a>! For more information and tips see our <a href="/meta/translation.md">translation guide</a>.</p>
     </div>
+    {% elif config.theme.language == "zh-Hant" %}
+    <div class="admonition info">
+    <p><a href="https://crowdin.com/project/privacyguides">您正在查看由我們在Crowdin上出色的語言團隊翻譯的《隱私指南》英文版。</a>如果您發現錯誤，或在此頁面上看到任何未翻譯的部分，<a href="https://matrix.to/#/#pg-i18n:aragon.sh">請考慮提供幫助</a>！有關更多信息和提示，請參閱我們的<a href="/meta/translation.md">翻譯指南</a>.</p>
+    <p>You're viewing the Chinese (Traditional) copy of Privacy Guides, translated by our fantastic language team on <a href="https://crowdin.com/project/privacyguides">Crowdin</a>. If you notice an error, or see any untranslated sections on this page, please consider <a href="https://matrix.to/#/#pg-i18n:aragon.sh">helping out</a>! For more information and tips see our <a href="/meta/translation.md">translation guide</a>.</p>
+    </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Changes proposed in this PR:

- Enable `zh-Hant` language
- Add translation notice to footer for `it` and `zh-Hant`