### PR TITLE
Fix buttons on tools page

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,14 +31,11 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid" markdown>
 
-[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
-{ .card }
+- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
 
-[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox)
-{ .card }
+- [![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
 
-[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave)
-{ .card }
+- [![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -30,9 +30,7 @@ For more details about each project, why they were chosen, and additional tips o
 ## Desktop Web Browsers
 
 [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
-
 [![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
-
 [![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
 
 [Learn more :material-arrow-right-drop-circle:](desktop-browsers.md)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,7 +15,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Tor Network
 
-[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button .md-button--primary }
+[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button }
 [![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } Orbot (Smartphone Tor Proxy)](tor.md#orbot){ .md-button }
 [![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } Snowflake](tor.md#snowflake){.md-button} (1)
 {.annotate}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,13 +15,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Tor Network
 
-<div class="grid cards annotate" markdown>
-
 [![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button }
 [![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } Orbot (Smartphone Tor Proxy)](tor.md#orbot){ .md-button }
 [![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } Snowflake](tor.md#snowflake){.md-button} (1)
-
-</div>
 
 1. Snowflake does not increase privacy, however it allows you to easily contribute to the Tor network and help people in censored networks achieve better privacy.
 
@@ -37,32 +33,20 @@ For more details about each project, why they were chosen, and additional tips o
 
 ### Additional Resources
 
-<div class="grid cards" markdown>
-
-- ![uBlock Origin logo](assets/img/browsers/ublock_origin.svg){ .twemoji } [uBlock Origin](desktop-browsers.md#ublock-origin)
-
-</div>
+[![uBlock Origin logo](assets/img/browsers/ublock_origin.svg){ .twemoji } uBlock Origin](desktop-browsers.md#ublock-origin){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](desktop-browsers.md#additional-resources)
 
 ## Mobile Web Browsers
 
-<div class="grid cards" markdown>
-
-- ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave (Android)](mobile-browsers.md#brave)
-- ![Safari logo](assets/img/browsers/safari.svg){ .twemoji } [Safari (iOS)](mobile-browsers.md#safari)
-
-</div>
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave (Android)](mobile-browsers.md#brave){md.button}
+[![Safari logo](assets/img/browsers/safari.svg){ .twemoji } Safari (iOS)](mobile-browsers.md#safari){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](mobile-browsers.md)
 
 ### Additional Resources
 
-<div class="grid cards annotate" markdown>
-
-- ![AdGuard logo](assets/img/browsers/adguard.svg){ .twemoji } [AdGuard for iOS](mobile-browsers.md#adguard)
-
-</div>
+[![AdGuard logo](assets/img/browsers/adguard.svg){ .twemoji } AdGuard for iOS](mobile-browsers.md#adguard){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](mobile-browsers.md#adguard)
 
@@ -70,12 +54,8 @@ For more details about each project, why they were chosen, and additional tips o
 
 ### Cloud Storage
 
-<div class="grid cards" markdown>
-
-- ![Proton Drive logo](assets/img/cloud/protondrive.svg){ .twemoji } [Proton Drive](cloud.md#proton-drive)
-- ![Tresorit logo](assets/img/cloud/tresorit.svg){ .twemoji } [Tresorit](cloud.md#tresorit)
-
-</div>
+[![Proton Drive logo](assets/img/cloud/protondrive.svg){ .twemoji } Proton Drive](cloud.md#proton-drive){.md-button}
+[![Tresorit logo](assets/img/cloud/tresorit.svg){ .twemoji } Tresorit](cloud.md#tresorit){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](cloud.md)
 
@@ -89,57 +69,37 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 #### Encrypted DNS Proxies
 
-<div class="grid cards" markdown>
-
-- ![RethinkDNS logo](assets/img/android/rethinkdns.svg#only-light){ .twemoji }![RethinkDNS logo](assets/img/android/rethinkdns-dark.svg#only-dark){ .twemoji } [RethinkDNS](dns.md#rethinkdns)
-- ![dnscrypt-proxy logo](assets/img/dns/dnscrypt-proxy.svg){ .twemoji } [dnscrypt-proxy](dns.md#dnscrypt-proxy)
-
-</div>
+[![RethinkDNS logo](assets/img/android/rethinkdns.svg#only-light){ .twemoji }![RethinkDNS logo](assets/img/android/rethinkdns-dark.svg#only-dark){ .twemoji } RethinkDNS](dns.md#rethinkdns){.md-button}
+[![dnscrypt-proxy logo](assets/img/dns/dnscrypt-proxy.svg){ .twemoji } dnscrypt-proxy](dns.md#dnscrypt-proxy){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](dns.md#encrypted-dns-proxies)
 
 #### Self-hosted Solutions
 
-<div class="grid cards" markdown>
-
-- ![AdGuard Home logo](assets/img/dns/adguard-home.svg){ .twemoji } [AdGuard Home](dns.md#adguard-home)
-- ![Pi-hole logo](assets/img/dns/pi-hole.svg){ .twemoji } [Pi-hole](dns.md#pi-hole)
-
-</div>
+[![AdGuard Home logo](assets/img/dns/adguard-home.svg){ .twemoji } AdGuard Home](dns.md#adguard-home){.md-button}
+[![Pi-hole logo](assets/img/dns/pi-hole.svg){ .twemoji } Pi-hole](dns.md#pi-hole){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](dns.md#self-hosted-solutions)
 
 ### Email
 
-<div class="grid cards" markdown>
-
-- ![Proton Mail logo](assets/img/email/protonmail.svg){ .twemoji } [Proton Mail](email.md#proton-mail)
-- ![Mailbox.org logo](assets/img/email/mailboxorg.svg){ .twemoji } [Mailbox.org](email.md#mailboxorg)
-- ![Tutanota logo](assets/img/email/tutanota.svg){ .twemoji } [Tutanota](email.md#tutanota)
-
-</div>
+[![Proton Mail logo](assets/img/email/protonmail.svg){ .twemoji } Proton Mail](email.md#proton-mail){.md-button}
+[![Mailbox.org logo](assets/img/email/mailboxorg.svg){ .twemoji } Mailbox.org](email.md#mailboxorg){.md-button}
+[![Tutanota logo](assets/img/email/tutanota.svg){ .twemoji } Tutanota](email.md#tutanota){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](email.md)
 
 #### Email Aliasing Services
 
-<div class="grid cards" markdown>
-
-- ![AnonAddy logo](assets/img/email/anonaddy.svg#only-light){ .twemoji }![AnonAddy logo](assets/img/email/anonaddy-dark.svg#only-dark){ .twemoji } [AnonAddy](email.md#anonaddy)
-- ![SimpleLogin logo](assets/img/email/simplelogin.svg){ .twemoji } [SimpleLogin](email.md#simplelogin)
-
-</div>
+[![AnonAddy logo](assets/img/email/anonaddy.svg#only-light){ .twemoji }![AnonAddy logo](assets/img/email/anonaddy-dark.svg#only-dark){ .twemoji } AnonAddy](email.md#anonaddy){.md-button}
+[![SimpleLogin logo](assets/img/email/simplelogin.svg){ .twemoji } SimpleLogin](email.md#simplelogin){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](email.md#email-aliasing-services)
 
 #### Self-Hosting Email
 
-<div class="grid cards" markdown>
-
-- ![mailcow logo](assets/img/email/mailcow.svg){ .twemoji } [mailcow](email.md#self-hosting-email)
-- ![Mail-in-a-Box logo](assets/img/email/mail-in-a-box.svg){ .twemoji } [Mail-in-a-Box](email.md#self-hosting-email)
-
-</div>
+[![mailcow logo](assets/img/email/mailcow.svg){ .twemoji } mailcow](email.md#self-hosting-email){.md-button}
+[![Mail-in-a-Box logo](assets/img/email/mail-in-a-box.svg){ .twemoji } Mail-in-a-Box](email.md#self-hosting-email){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](email.md#self-hosting-email)
 
@@ -147,35 +107,24 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 #### Payment Masking Services
 
-<div class="grid cards" markdown>
-
-- ![Privacy.com logo](assets/img/financial-services/privacy_com.svg#only-light){ .twemoji }![Privacy.com logo](assets/img/financial-services/privacy_com-dark.svg#only-dark){ .twemoji } [Privacy.com](financial-services.md#privacycom-us-free)
-- ![MySudo logo](assets/img/financial-services/mysudo.svg#only-light){ .twemoji }![MySudo logo](assets/img/financial-services/mysudo-dark.svg#only-dark){ .twemoji } [MySudo](financial-services.md#mysudo-us-paid)
-</div>
+[![Privacy.com logo](assets/img/financial-services/privacy_com.svg#only-light){ .twemoji }![Privacy.com logo](assets/img/financial-services/privacy_com-dark.svg#only-dark){ .twemoji } Privacy.com](financial-services.md#privacycom-us-free){.md-button}
+[![MySudo logo](assets/img/financial-services/mysudo.svg#only-light){ .twemoji }![MySudo logo](assets/img/financial-services/mysudo-dark.svg#only-dark){ .twemoji } MySudo](financial-services.md#mysudo-us-paid){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](financial-services.md#payment-masking-services)
 
 #### Online Gift Card Marketplaces
 
-<div class="grid cards" markdown>
-
-- ![Cake Pay logo](assets/img/financial-services/cakepay.svg){ .twemoji } [Cake Pay](financial-services.md#cake-pay)
-- ![CoinCards logo](assets/img/financial-services/coincards.svg){ .twemoji } [CoinCards](financial-services.md#coincards)
-
-</div>
+[![Cake Pay logo](assets/img/financial-services/cakepay.svg){ .twemoji } Cake Pay](financial-services.md#cake-pay){.md-button}
+[![CoinCards logo](assets/img/financial-services/coincards.svg){ .twemoji } CoinCards](financial-services.md#coincards){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](financial-services.md#gift-card-marketplaces)
 
 ### Search Engines
 
-<div class="grid cards" markdown>
-
-- ![Brave Search logo](assets/img/search-engines/brave-search.svg){ .twemoji } [Brave Search](search-engines.md#brave-search)
-- ![DuckDuckGo logo](assets/img/search-engines/duckduckgo.svg){ .twemoji } [DuckDuckGo](search-engines.md#duckduckgo)
-- ![SearXNG logo](assets/img/search-engines/searxng.svg){ .twemoji } [SearXNG](search-engines.md#searxng)
-- ![Startpage logo](assets/img/search-engines/startpage.svg#only-light){ .twemoji }![Startpage logo](assets/img/search-engines/startpage-dark.svg#only-dark){ .twemoji } [Startpage](search-engines.md#startpage)
-
-</div>
+[![Brave Search logo](assets/img/search-engines/brave-search.svg){ .twemoji } Brave Search](search-engines.md#brave-search){.md-button}
+[![DuckDuckGo logo](assets/img/search-engines/duckduckgo.svg){ .twemoji } DuckDuckGo](search-engines.md#duckduckgo){.md-button}
+[![SearXNG logo](assets/img/search-engines/searxng.svg){ .twemoji } SearXNG](search-engines.md#searxng){.md-button}
+[![Startpage logo](assets/img/search-engines/startpage.svg#only-light){ .twemoji }![Startpage logo](assets/img/search-engines/startpage-dark.svg#only-dark){ .twemoji } Startpage](search-engines.md#startpage){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](search-engines.md)
 
@@ -191,13 +140,9 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
     [Learn more :material-arrow-right-drop-circle:](vpn.md)
 
-<div class="grid cards" markdown>
-
-- ![IVPN logo](assets/img/vpn/mini/ivpn.svg){ .twemoji } [IVPN](vpn.md#ivpn)
-- ![Mullvad logo](assets/img/vpn/mullvad.svg){ .twemoji } [Mullvad](vpn.md#mullvad)
-- ![Proton VPN logo](assets/img/vpn/protonvpn.svg){ .twemoji } [Proton VPN](vpn.md#proton-vpn)
-
-</div>
+[![IVPN logo](assets/img/vpn/mini/ivpn.svg){ .twemoji } IVPN](vpn.md#ivpn){.md-button}
+[![Mullvad logo](assets/img/vpn/mullvad.svg){ .twemoji } Mullvad](vpn.md#mullvad){.md-button}
+[![Proton VPN logo](assets/img/vpn/protonvpn.svg){ .twemoji } Proton VPN](vpn.md#proton-vpn){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](vpn.md)
 
@@ -205,54 +150,38 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 ### Calendar Sync
 
-<div class="grid cards" markdown>
-
-- ![Tutanota logo](assets/img/calendar/tutanota.svg){ .twemoji } [Tutanota](calendar.md#tutanota)
-- ![Proton Calendar logo](assets/img/calendar/proton-calendar.svg){ .twemoji } [Proton Calendar](calendar.md#proton-calendar)
-
-</div>
+[![Tutanota logo](assets/img/calendar/tutanota.svg){ .twemoji } Tutanota](calendar.md#tutanota){.md-button}
+[![Proton Calendar logo](assets/img/calendar/proton-calendar.svg){ .twemoji } Proton Calendar](calendar.md#proton-calendar){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](calendar.md)
 
 ### Cryptocurrency
 
-<div class="grid cards" markdown>
-
-- ![Monero logo](assets/img/cryptocurrency/monero.svg){ .twemoji } [Monero](cryptocurrency.md#monero)
-
-</div>
+[![Monero logo](assets/img/cryptocurrency/monero.svg){ .twemoji } Monero](cryptocurrency.md#monero){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](cryptocurrency.md)
 
 ### Data and Metadata Redaction
 
-<div class="grid cards" markdown>
-
-- ![MAT2 logo](assets/img/data-redaction/mat2.svg){ .twemoji } [MAT2](data-redaction.md#mat2)
-- ![ExifEraser logo](assets/img/data-redaction/exiferaser.svg){ .twemoji } [ExifEraser (Android)](data-redaction.md#exiferaser-android)
-- ![Metapho logo](assets/img/data-redaction/metapho.jpg){ .twemoji } [Metapho (iOS)](data-redaction.md#metapho-ios)
-- ![PrivacyBlur logo](assets/img/data-redaction/privacyblur.svg){ .twemoji } [PrivacyBlur](data-redaction.md#privacyblur)
-- ![ExifTool logo](assets/img/data-redaction/exiftool.png){ .twemoji } [ExifTool (CLI)](data-redaction.md#exiftool)
-
-</div>
+[![MAT2 logo](assets/img/data-redaction/mat2.svg){ .twemoji } MAT2](data-redaction.md#mat2){.md-button}
+[![ExifEraser logo](assets/img/data-redaction/exiferaser.svg){ .twemoji } ExifEraser (Android)](data-redaction.md#exiferaser-android){.md-button}
+[![Metapho logo](assets/img/data-redaction/metapho.jpg){ .twemoji } Metapho (iOS)](data-redaction.md#metapho-ios){.md-button}
+[![PrivacyBlur logo](assets/img/data-redaction/privacyblur.svg){ .twemoji } PrivacyBlur](data-redaction.md#privacyblur){.md-button}
+[![ExifTool logo](assets/img/data-redaction/exiftool.png){ .twemoji } ExifTool (CLI)](data-redaction.md#exiftool){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](data-redaction.md)
 
 ### Email Clients
 
-<div class="grid cards" markdown>
-
-- ![Thunderbird logo](assets/img/email-clients/thunderbird.svg){ .twemoji } [Thunderbird](email-clients.md#thunderbird)
-- ![Apple Mail logo](assets/img/email-clients/applemail.png){ .twemoji } [Apple Mail (macOS)](email-clients.md#apple-mail-macos)
-- ![Canary Mail logo](assets/img/email-clients/canarymail.svg){ .twemoji } [Canary Mail (iOS)](email-clients.md#canary-mail-ios)
-- ![FairEmail logo](assets/img/email-clients/fairemail.svg){ .twemoji } [FairEmail (Android)](email-clients.md#fairemail-android)
-- ![GNOME Evolution logo](assets/img/email-clients/evolution.svg){ .twemoji } [GNOME Evolution (Linux)](email-clients.md#gnome-evolution-gnome)
-- ![K-9 Mail logo](assets/img/email-clients/k9mail.svg){ .twemoji } [K-9 Mail (Android)](email-clients.md#k-9-mail-android)
-- ![Kontact logo](assets/img/email-clients/kontact.svg){ .twemoji } [Kontact (Linux)](email-clients.md#kontact-kde)
-- ![Mailvelope logo](assets/img/email-clients/mailvelope.svg){ .twemoji } [Mailvelope (PGP in standard webmail)](email-clients.md#mailvelope-browser)
-- ![NeoMutt logo](assets/img/email-clients/mutt.svg){ .twemoji } [NeoMutt (CLI)](email-clients.md#neomutt-cli)
-
-</div>
+[![Thunderbird logo](assets/img/email-clients/thunderbird.svg){ .twemoji } Thunderbird](email-clients.md#thunderbird){.md-button}
+[![Apple Mail logo](assets/img/email-clients/applemail.png){ .twemoji } Apple Mail (macOS)](email-clients.md#apple-mail-macos){.md-button}
+[![Canary Mail logo](assets/img/email-clients/canarymail.svg){ .twemoji } Canary Mail (iOS)](email-clients.md#canary-mail-ios){.md-button}
+[![FairEmail logo](assets/img/email-clients/fairemail.svg){ .twemoji } FairEmail (Android)](email-clients.md#fairemail-android){.md-button}
+[![GNOME Evolution logo](assets/img/email-clients/evolution.svg){ .twemoji } GNOME Evolution (Linux)](email-clients.md#gnome-evolution-gnome){.md-button}
+[![K-9 Mail logo](assets/img/email-clients/k9mail.svg){ .twemoji } K-9 Mail (Android)](email-clients.md#k-9-mail-android){.md-button}
+[![Kontact logo](assets/img/email-clients/kontact.svg){ .twemoji } Kontact (Linux)](email-clients.md#kontact-kde){.md-button}
+[![Mailvelope logo](assets/img/email-clients/mailvelope.svg){ .twemoji } Mailvelope (PGP in standard webmail)](email-clients.md#mailvelope-browser){.md-button}
+[![NeoMutt logo](assets/img/email-clients/mutt.svg){ .twemoji } NeoMutt (CLI)](email-clients.md#neomutt-cli){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](email-clients.md)
 
@@ -264,29 +193,21 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
     [Learn more :material-arrow-right-drop-circle:](encryption.md##operating-system-included-full-disk-encryption-fde)
 
-<div class="grid cards" markdown>
-
-- ![Cryptomator logo](assets/img/encryption-software/cryptomator.svg){ .twemoji } [Cryptomator](encryption.md#cryptomator-cloud)
-- ![Picocrypt logo](assets/img/encryption-software/picocrypt.svg){ .twemoji } [Picocrypt](encryption.md#picocrypt-file)
-- ![VeraCrypt logo](assets/img/encryption-software/veracrypt.svg#only-light){ .twemoji }![VeraCrypt logo](assets/img/encryption-software/veracrypt-dark.svg#only-dark){ .twemoji } [VeraCrypt (FDE)](encryption.md#veracrypt-disk)
-- ![Hat.sh logo](assets/img/encryption-software/hat-sh.png#only-light){ .twemoji }![Hat.sh logo](assets/img/encryption-software/hat-sh-dark.png#only-dark){ .twemoji } [Hat.sh (Browser-based)](encryption.md#hatsh)
-- ![Kryptor logo](assets/img/encryption-software/kryptor.png){ .twemoji } [Kryptor](encryption.md#kryptor)
-- ![Tomb logo](assets/img/encryption-software/tomb.png){ .twemoji } [Tomb](encryption.md#tomb)
-
-</div>
+[![Cryptomator logo](assets/img/encryption-software/cryptomator.svg){ .twemoji } Cryptomator](encryption.md#cryptomator-cloud){.md-button}
+[![Picocrypt logo](assets/img/encryption-software/picocrypt.svg){ .twemoji } Picocrypt](encryption.md#picocrypt-file){.md-button}
+[![VeraCrypt logo](assets/img/encryption-software/veracrypt.svg#only-light){ .twemoji }![VeraCrypt logo](assets/img/encryption-software/veracrypt-dark.svg#only-dark){ .twemoji } VeraCrypt (FDE)](encryption.md#veracrypt-disk){.md-button}
+[![Hat.sh logo](assets/img/encryption-software/hat-sh.png#only-light){ .twemoji }![Hat.sh logo](assets/img/encryption-software/hat-sh-dark.png#only-dark){ .twemoji } Hat.sh (Browser-based)](encryption.md#hatsh){.md-button}
+[![Kryptor logo](assets/img/encryption-software/kryptor.png){ .twemoji } Kryptor](encryption.md#kryptor){.md-button}
+[![Tomb logo](assets/img/encryption-software/tomb.png){ .twemoji } Tomb](encryption.md#tomb){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](encryption.md)
 
 #### OpenPGP Clients
 
-<div class="grid cards" markdown>
-
-- ![GnuPG logo](assets/img/encryption-software/gnupg.svg){ .twemoji } [GnuPG](encryption.md#gnu-privacy-guard)
-- ![GPG4Win logo](assets/img/encryption-software/gpg4win.svg){ .twemoji } [GPG4Win (Windows)](encryption.md#gpg4win)
-- ![GPG Suite logo](assets/img/encryption-software/gpgsuite.png){ .twemoji } [GPG Suite (macOS)](encryption.md#gpg-suite)
-- ![OpenKeychain logo](assets/img/encryption-software/openkeychain.svg){ .twemoji } [OpenKeychain](encryption.md#openkeychain)
-
-</div>
+[![GnuPG logo](assets/img/encryption-software/gnupg.svg){ .twemoji } GnuPG](encryption.md#gnu-privacy-guard){.md-button}
+[![GPG4Win logo](assets/img/encryption-software/gpg4win.svg){ .twemoji } GPG4Win (Windows)](encryption.md#gpg4win){.md-button}
+[![GPG Suite logo](assets/img/encryption-software/gpgsuite.png){ .twemoji } GPG Suite (macOS)](encryption.md#gpg-suite){.md-button}
+[![OpenKeychain logo](assets/img/encryption-software/openkeychain.svg){ .twemoji } OpenKeychain](encryption.md#openkeychain){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](encryption.md#openpgp)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,9 +31,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid" markdown>
 
-[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
-[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox)
-[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave)
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
+[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards annotate" markdown>
 
-- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser)
+- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser){ .md-button }
 - ![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } [Orbot (Smartphone Tor Proxy)](tor.md#orbot)
 - ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } [Snowflake](tor.md#snowflake) (1)
 
@@ -31,7 +31,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser)
+- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
 - ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
 - ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,11 +31,11 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid" markdown>
 
-- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
 
-- [![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
+[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
 
-- [![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards annotate" markdown>
 
-- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser){ .md-button }
+- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser)
 - ![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } [Orbot (Smartphone Tor Proxy)](tor.md#orbot)
 - ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } [Snowflake](tor.md#snowflake) (1)
 
@@ -31,7 +31,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
+- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser)
 - ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
 - ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards annotate" markdown>
 
-- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser)
+[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser{ .card }](tor.md#tor-browser)
 - ![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } [Orbot (Smartphone Tor Proxy)](tor.md#orbot)
 - ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } [Snowflake](tor.md#snowflake) (1)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,9 +31,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-[- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
-- ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
-- ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser]](desktop-browsers.md#mullvad-browser){ .md-button }
+![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
+![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,7 +31,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser)
+- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji }](desktop-browsers.md#mullvad-browser) Mullvad Browser
 - ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
 - ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,7 +31,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
+[- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
 - ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
 - ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,8 +33,10 @@ For more details about each project, why they were chosen, and additional tips o
 
 [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
 { .card }
+
 [![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox)
 { .card }
+
 [![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave)
 { .card }
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,11 +29,11 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Desktop Web Browsers
 
-<div class="grid cards" markdown>
+<div class="grid" markdown>
 
-- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser)
-- ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
-- ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser{ .card }](desktop-browsers.md#mullvad-browser)
+[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox{ .card }](desktop-browsers.md#firefox)
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave{ .card }](desktop-browsers.md#brave)
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,11 +29,11 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Desktop Web Browsers
 
-<div class="grid cards" markdown>
+<div class="grid" markdown>
 
-- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser]](desktop-browsers.md#mullvad-browser)
-- ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
-- ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
+[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox)
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave)
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,7 +31,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji }](desktop-browsers.md#mullvad-browser) Mullvad Browser
+- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
 - ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
 - ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,9 +31,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards" markdown>
 
-[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser]](desktop-browsers.md#mullvad-browser){ .md-button }
-![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
-![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
+- [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser]](desktop-browsers.md#mullvad-browser)
+- ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
+- ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,7 +15,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Tor Network
 
-[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button }
+[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button .md-button--primary }
 [![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } Orbot (Smartphone Tor Proxy)](tor.md#orbot){ .md-button }
 [![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } Snowflake](tor.md#snowflake){.md-button} (1)
 {.annotate}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,15 +29,11 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Desktop Web Browsers
 
-<div class="grid" markdown>
-
 [![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
 
 [![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
 
 [![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
-
-</div>
 
 [Learn more :material-arrow-right-drop-circle:](desktop-browsers.md)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -214,128 +214,92 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 ### File Sharing and Sync
 
-<div class="grid cards" markdown>
-
-- ![Send logo](assets/img/file-sharing-sync/send.svg){ .twemoji } [Send](file-sharing.md#send)
-- ![OnionShare logo](assets/img/file-sharing-sync/onionshare.svg){ .twemoji } [OnionShare](file-sharing.md#onionshare)
-- ![FreedomBox logo](assets/img/file-sharing-sync/freedombox.svg){ .twemoji } [FreedomBox](file-sharing.md#freedombox)
-- ![Nextcloud logo](assets/img/productivity/nextcloud.svg){ .twemoji } [Nextcloud (Self-Hostable)](file-sharing.md#nextcloud-client-server)
-- ![Syncthing logo](assets/img/file-sharing-sync/syncthing.svg){ .twemoji } [Syncthing](file-sharing.md#syncthing-p2p)
-
-</div>
+[![Send logo](assets/img/file-sharing-sync/send.svg){ .twemoji } Send](file-sharing.md#send){.md-button}
+[![OnionShare logo](assets/img/file-sharing-sync/onionshare.svg){ .twemoji } OnionShare](file-sharing.md#onionshare){.md-button}
+[![FreedomBox logo](assets/img/file-sharing-sync/freedombox.svg){ .twemoji } FreedomBox](file-sharing.md#freedombox){.md-button}
+[![Nextcloud logo](assets/img/productivity/nextcloud.svg){ .twemoji } Nextcloud (Self-Hostable)](file-sharing.md#nextcloud-client-server){.md-button}
+[![Syncthing logo](assets/img/file-sharing-sync/syncthing.svg){ .twemoji } Syncthing](file-sharing.md#syncthing-p2p){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](file-sharing.md)
 
 ### Frontends
 
-<div class="grid cards" markdown>
-
-- ![Nitter logo](assets/img/frontends/nitter.svg){ .twemoji } [Nitter (Twitter, Web)](frontends.md#nitter)
-- ![FreeTube logo](assets/img/frontends/freetube.svg){ .twemoji } [FreeTube (YouTube, Desktop)](frontends.md#freetube)
-- ![Yattee logo](assets/img/frontends/yattee.svg){ .twemoji } [Yattee (YouTube; iOS, tvOS, macOS)](frontends.md#yattee)
-- ![LibreTube logo](assets/img/frontends/libretube.svg#only-light){ .twemoji }![LibreTube logo](assets/img/frontends/libretube-dark.svg#only-dark){ .twemoji } [LibreTube (YouTube, Android)](frontends.md#libretube-android)  
-- ![NewPipe logo](assets/img/frontends/newpipe.svg){ .twemoji } [NewPipe (YouTube, Android)](frontends.md#newpipe-android)
-- ![Invidious logo](assets/img/frontends/invidious.svg#only-light){ .twemoji }![Invidious logo](assets/img/frontends/invidious-dark.svg#only-dark){ .twemoji } [Invidious (YouTube, Web)](frontends.md#invidious)
-- ![Piped logo](assets/img/frontends/piped.svg){ .twemoji } [Piped (YouTube, Web)](frontends.md#piped)
-
-</div>
+[![Nitter logo](assets/img/frontends/nitter.svg){ .twemoji } Nitter (Twitter, Web)](frontends.md#nitter){.md-button}
+[![FreeTube logo](assets/img/frontends/freetube.svg){ .twemoji } FreeTube (YouTube, Desktop)](frontends.md#freetube){.md-button}
+[![Yattee logo](assets/img/frontends/yattee.svg){ .twemoji } Yattee (YouTube; iOS, tvOS, macOS)](frontends.md#yattee){.md-button}
+[![LibreTube logo](assets/img/frontends/libretube.svg#only-light){ .twemoji }![LibreTube logo](assets/img/frontends/libretube-dark.svg#only-dark){ .twemoji } LibreTube (YouTube, Android)](frontends.md#libretube-android){.md-button}
+[![NewPipe logo](assets/img/frontends/newpipe.svg){ .twemoji } NewPipe (YouTube, Android)](frontends.md#newpipe-android){.md-button}
+[![Invidious logo](assets/img/frontends/invidious.svg#only-light){ .twemoji }![Invidious logo](assets/img/frontends/invidious-dark.svg#only-dark){ .twemoji } Invidious (YouTube, Web)](frontends.md#invidious){.md-button}
+[![Piped logo](assets/img/frontends/piped.svg){ .twemoji } Piped (YouTube, Web)](frontends.md#piped){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](frontends.md)
 
 ### Multi-Factor Authentication Tools
 
-<div class="grid cards" markdown>
-
-- ![YubiKeys](assets/img/multi-factor-authentication/mini/yubico.svg){ .twemoji } [YubiKey](multi-factor-authentication.md#yubikey)
-- ![Nitrokey](assets/img/multi-factor-authentication/mini/nitrokey.svg){ .twemoji } [Nitrokey](multi-factor-authentication.md#nitrokey)
-- ![Aegis logo](assets/img/multi-factor-authentication/aegis.png){ .twemoji } [Aegis Authenticator](multi-factor-authentication.md#aegis-authenticator)
-- ![Raivo OTP logo](assets/img/multi-factor-authentication/raivo-otp.png){ .twemoji } [Raivo OTP](multi-factor-authentication.md#raivo-otp)
-
-</div>
+[![YubiKeys](assets/img/multi-factor-authentication/mini/yubico.svg){ .twemoji } YubiKey](multi-factor-authentication.md#yubikey){.md-button}
+[![Nitrokey](assets/img/multi-factor-authentication/mini/nitrokey.svg){ .twemoji } Nitrokey](multi-factor-authentication.md#nitrokey){.md-button}
+[![Aegis logo](assets/img/multi-factor-authentication/aegis.png){ .twemoji } Aegis Authenticator](multi-factor-authentication.md#aegis-authenticator){.md-button}
+[![Raivo OTP logo](assets/img/multi-factor-authentication/raivo-otp.png){ .twemoji } Raivo OTP](multi-factor-authentication.md#raivo-otp){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](multi-factor-authentication.md)
 
 ### News Aggregators
 
-<div class="grid cards" markdown>
-
-- ![Akregator logo](assets/img/news-aggregators/akregator.svg){ .twemoji } [Akregator](news-aggregators.md#akregator)
-- ![Feeder logo](assets/img/news-aggregators/feeder.png){ .twemoji} [Feeder](news-aggregators.md#feeder)
-- ![Fluent Reader logo](assets/img/news-aggregators/fluent-reader.svg){ .twemoji } [Fluent Reader](news-aggregators.md#fluent-reader)
-- ![GNOME Feeds logo](assets/img/news-aggregators/gfeeds.svg){ .twemoji } [GNOME Feeds](news-aggregators.md#gnome-feeds)
-- ![Miniflux logo](assets/img/news-aggregators/miniflux.svg#only-light){ .twemoji }![Miniflux logo](assets/img/news-aggregators/miniflux-dark.svg#only-dark){ .twemoji } [Miniflux](news-aggregators.md#miniflux)
-- ![NetNewsWire logo](assets/img/news-aggregators/netnewswire.png){ .twemoji } [NetNewsWire](news-aggregators.md#netnewswire)
-- ![Newsboat logo](assets/img/news-aggregators/newsboat.svg){ .twemoji } [Newsboat](news-aggregators.md#newsboat)
-
-</div>
+[![Akregator logo](assets/img/news-aggregators/akregator.svg){ .twemoji } Akregator](news-aggregators.md#akregator){.md-button}
+[![Feeder logo](assets/img/news-aggregators/feeder.png){ .twemoji} Feeder](news-aggregators.md#feeder){.md-button}
+[![Fluent Reader logo](assets/img/news-aggregators/fluent-reader.svg){ .twemoji } Fluent Reader](news-aggregators.md#fluent-reader){.md-button}
+[![GNOME Feeds logo](assets/img/news-aggregators/gfeeds.svg){ .twemoji } GNOME Feeds](news-aggregators.md#gnome-feeds){.md-button}
+[![Miniflux logo](assets/img/news-aggregators/miniflux.svg#only-light){ .twemoji }![Miniflux logo](assets/img/news-aggregators/miniflux-dark.svg#only-dark){ .twemoji } Miniflux](news-aggregators.md#miniflux){.md-button}
+[![NetNewsWire logo](assets/img/news-aggregators/netnewswire.png){ .twemoji } NetNewsWire](news-aggregators.md#netnewswire){.md-button}
+[![Newsboat logo](assets/img/news-aggregators/newsboat.svg){ .twemoji } Newsboat](news-aggregators.md#newsboat){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](news-aggregators.md)
 
 ### Notebooks
 
-<div class="grid cards" markdown>
-
-- ![Standard Notes logo](assets/img/notebooks/standard-notes.svg){ .twemoji } [Standard Notes](notebooks.md#standard-notes)
-- ![Notesnook logo](assets/img/notebooks/notesnook.svg){ .twemoji } [Notesnook](notebooks.md#notesnook)
-- ![Joplin logo](assets/img/notebooks/joplin.svg){ .twemoji } [Joplin](notebooks.md#joplin)
-- ![Cryptee logo](assets/img/notebooks/cryptee.svg#only-light){ .twemoji }![Cryptee logo](assets/img/notebooks/cryptee-dark.svg#only-dark){ .twemoji } [Cryptee](notebooks.md#cryptee)
-- ![Org-mode logo](assets/img/notebooks/org-mode.svg){ .twemoji } [Org-mode](notebooks.md#org-mode)
-
-</div>
+[![Standard Notes logo](assets/img/notebooks/standard-notes.svg){ .twemoji } Standard Notes](notebooks.md#standard-notes){.md-button}
+[![Notesnook logo](assets/img/notebooks/notesnook.svg){ .twemoji } Notesnook](notebooks.md#notesnook){.md-button}
+[![Joplin logo](assets/img/notebooks/joplin.svg){ .twemoji } Joplin](notebooks.md#joplin){.md-button}
+[![Cryptee logo](assets/img/notebooks/cryptee.svg#only-light){ .twemoji }![Cryptee logo](assets/img/notebooks/cryptee-dark.svg#only-dark){ .twemoji } Cryptee](notebooks.md#cryptee){.md-button}
+[![Org-mode logo](assets/img/notebooks/org-mode.svg){ .twemoji } Org-mode](notebooks.md#org-mode){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](notebooks.md)
 
 ### Password Managers
 
-<div class="grid cards" markdown>
-
-- ![Bitwarden logo](assets/img/password-management/bitwarden.svg){ .twemoji } [Bitwarden](passwords.md#bitwarden)
-- ![1Password logo](assets/img/password-management/1password.svg){ .twemoji } [1Password](passwords.md#1password)
-- ![Psono logo](assets/img/password-management/psono.svg){ .twemoji } [Psono](passwords.md#psono)
-- ![KeePassXC logo](assets/img/password-management/keepassxc.svg){ .twemoji } [KeePassXC](passwords.md#keepassxc)
-- ![KeePassDX logo](assets/img/password-management/keepassdx.svg){ .twemoji } [KeePassDX (Android)](passwords.md#keepassdx-android)
-- ![Strongbox logo](assets/img/password-management/strongbox.svg){ .twemoji } [Strongbox (iOS & macOS)](passwords.md#strongbox-ios-macos)
-- ![gopass logo](assets/img/password-management/gopass.svg){ .twemoji } [gopass](passwords.md#gopass)
-
-</div>
+[![Bitwarden logo](assets/img/password-management/bitwarden.svg){ .twemoji } Bitwarden](passwords.md#bitwarden){.md-button}
+[![1Password logo](assets/img/password-management/1password.svg){ .twemoji } 1Password](passwords.md#1password){.md-button}
+[![Psono logo](assets/img/password-management/psono.svg){ .twemoji } Psono](passwords.md#psono){.md-button}
+[![KeePassXC logo](assets/img/password-management/keepassxc.svg){ .twemoji } KeePassXC](passwords.md#keepassxc){.md-button}
+[![KeePassDX logo](assets/img/password-management/keepassdx.svg){ .twemoji } KeePassDX (Android)](passwords.md#keepassdx-android){.md-button}
+[![Strongbox logo](assets/img/password-management/strongbox.svg){ .twemoji } Strongbox (iOS & macOS)](passwords.md#strongbox-ios-macos){.md-button}
+[![gopass logo](assets/img/password-management/gopass.svg){ .twemoji } gopass](passwords.md#gopass){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](passwords.md)
 
 ### Productivity Tools
 
-<div class="grid cards" markdown>
-
-- ![Nextcloud logo](assets/img/productivity/nextcloud.svg){ .twemoji } [Nextcloud (Self-Hostable)](productivity.md#nextcloud)
-- ![LibreOffice logo](assets/img/productivity/libreoffice.svg){ .twemoji } [LibreOffice](productivity.md#libreoffice)
-- ![OnlyOffice logo](assets/img/productivity/onlyoffice.svg){ .twemoji } [OnlyOffice](productivity.md#onlyoffice)
-- ![CryptPad logo](assets/img/productivity/cryptpad.svg){ .twemoji } [CryptPad](productivity.md#cryptpad)
-- ![PrivateBin logo](assets/img/productivity/privatebin.svg){ .twemoji } [PrivateBin (Pastebin)](productivity.md#privatebin)
-
-</div>
+[![Nextcloud logo](assets/img/productivity/nextcloud.svg){ .twemoji } Nextcloud (Self-Hostable)](productivity.md#nextcloud){.md-button}
+[![LibreOffice logo](assets/img/productivity/libreoffice.svg){ .twemoji } LibreOffice](productivity.md#libreoffice){.md-button}
+[![OnlyOffice logo](assets/img/productivity/onlyoffice.svg){ .twemoji } OnlyOffice](productivity.md#onlyoffice){.md-button}
+[![CryptPad logo](assets/img/productivity/cryptpad.svg){ .twemoji } CryptPad](productivity.md#cryptpad){.md-button}
+[![PrivateBin logo](assets/img/productivity/privatebin.svg){ .twemoji } PrivateBin (Pastebin)](productivity.md#privatebin){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](productivity.md)
 
 ### Real-Time Communication
 
-<div class="grid cards" markdown>
-
-- ![Signal logo](assets/img/messengers/signal.svg){ .twemoji } [Signal](real-time-communication.md#signal)
-- ![Briar logo](assets/img/messengers/briar.svg){ .twemoji } [Briar](real-time-communication.md#briar)
-- ![SimpleX Chat logo](assets/img/messengers/simplex.svg){ .twemoji } [SimpleX Chat](real-time-communication.md#simplex-chat)
-- ![Element logo](assets/img/messengers/element.svg){ .twemoji } [Element](real-time-communication.md#element)
-- ![Session logo](assets/img/messengers/session.svg){ .twemoji } [Session](real-time-communication.md#session)
-
-</div>
+[![Signal logo](assets/img/messengers/signal.svg){ .twemoji } Signal](real-time-communication.md#signal){.md-button}
+[![Briar logo](assets/img/messengers/briar.svg){ .twemoji } Briar](real-time-communication.md#briar){.md-button}
+[![SimpleX Chat logo](assets/img/messengers/simplex.svg){ .twemoji } SimpleX Chat](real-time-communication.md#simplex-chat){.md-button}
+[![Element logo](assets/img/messengers/element.svg){ .twemoji } Element](real-time-communication.md#element){.md-button}
+[![Session logo](assets/img/messengers/session.svg){ .twemoji } Session](real-time-communication.md#session){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](real-time-communication.md)
 
 ### Video Streaming Clients
 
-<div class="grid cards" markdown>
-
-- ![LBRY logo](assets/img/video-streaming/lbry.svg){ .twemoji } [LBRY](video-streaming.md#lbry)
-
-</div>
+[![LBRY logo](assets/img/video-streaming/lbry.svg){ .twemoji } LBRY](video-streaming.md#lbry){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](video-streaming.md)
 
@@ -343,53 +307,37 @@ We [recommend](dns.md#recommended-providers) a number of encrypted DNS servers b
 
 ### Mobile
 
-<div class="grid cards" markdown>
-
-- ![GrapheneOS logo](assets/img/android/grapheneos.svg#only-light){ .twemoji }![GrapheneOS logo](assets/img/android/grapheneos-dark.svg#only-dark){ .twemoji } [GrapheneOS](android.md#grapheneos)
-- ![DivestOS logo](assets/img/android/divestos.svg){ .twemoji } [DivestOS](android.md#divestos)
-
-</div>
+[![GrapheneOS logo](assets/img/android/grapheneos.svg#only-light){ .twemoji }![GrapheneOS logo](assets/img/android/grapheneos-dark.svg#only-dark){ .twemoji } GrapheneOS](android.md#grapheneos){.md-button}
+[![DivestOS logo](assets/img/android/divestos.svg){ .twemoji } DivestOS](android.md#divestos){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](android.md)
 
 #### Android Apps
 
-<div class="grid cards" markdown>
-
-- ![Aurora Store logo](assets/img/android/aurora-store.webp){ .twemoji } [Aurora Store (Google Play Client)](android.md#aurora-store)
-- ![Shelter logo](assets/img/android/mini/shelter.svg){ .twemoji } [Shelter (Work Profiles)](android.md#shelter)
-- ![Auditor logo](assets/img/android/auditor.svg#only-light){ .twemoji }![GrapheneOS logo](assets/img/android/auditor-dark.svg#only-dark){ .twemoji } [Auditor (Supported Devices)](android.md#auditor)
-- ![Secure Camera logo](assets/img/android/secure_camera.svg#only-light){ .twemoji }![Secure Camera logo](assets/img/android/secure_camera-dark.svg#only-dark){ .twemoji } [Secure Camera](android.md#secure-camera)
-- ![Secure PDF Viewer logo](assets/img/android/secure_pdf_viewer.svg#only-light){ .twemoji }![GrapheneOS logo](assets/img/android/secure_pdf_viewer-dark.svg#only-dark){ .twemoji } [Secure PDF Viewer](android.md#secure-pdf-viewer)
-
-</div>
+[![Aurora Store logo](assets/img/android/aurora-store.webp){ .twemoji } Aurora Store (Google Play Client)](android.md#aurora-store){.md-button}
+[![Shelter logo](assets/img/android/mini/shelter.svg){ .twemoji } Shelter (Work Profiles)](android.md#shelter){.md-button}
+[![Auditor logo](assets/img/android/auditor.svg#only-light){ .twemoji }![GrapheneOS logo](assets/img/android/auditor-dark.svg#only-dark){ .twemoji } Auditor (Supported Devices)](android.md#auditor){.md-button}
+[![Secure Camera logo](assets/img/android/secure_camera.svg#only-light){ .twemoji }![Secure Camera logo](assets/img/android/secure_camera-dark.svg#only-dark){ .twemoji } Secure Camera](android.md#secure-camera){.md-button}
+[![Secure PDF Viewer logo](assets/img/android/secure_pdf_viewer.svg#only-light){ .twemoji }![GrapheneOS logo](assets/img/android/secure_pdf_viewer-dark.svg#only-dark){ .twemoji } Secure PDF Viewer](android.md#secure-pdf-viewer){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](android.md#general-apps)
 
 ### Desktop/PC
 
-<div class="grid cards" markdown>
-
-- ![Qubes OS logo](assets/img/qubes/qubes_os.svg){ .twemoji } [Qubes OS (Xen VM Distribution)](desktop.md#qubes-os)
-- ![Fedora logo](assets/img/linux-desktop/fedora-workstation.svg){ .twemoji } [Fedora Workstation](desktop.md#fedora-workstation)
-- ![openSUSE Tumbleweed logo](assets/img/linux-desktop/opensuse-tumbleweed.svg){ .twemoji } [OpenSUSE Tumbleweed](desktop.md#opensuse-tumbleweed)
-- ![Arch logo](assets/img/linux-desktop/archlinux.svg){ .twemoji } [Arch Linux](desktop.md#arch-linux)
-- ![Fedora Silverblue logo](assets/img/linux-desktop/fedora-silverblue.svg){ .twemoji } [Fedora Silverblue & Kinoite](desktop.md#fedora-silverblue)
-- ![nixOS logo](assets/img/linux-desktop/nixos.svg){ .twemoji } [NixOS](desktop.md#nixos)
-- ![Whonix logo](assets/img/linux-desktop/whonix.svg){ .twemoji } [Whonix (Tor)](desktop.md#whonix)
-- ![Tails logo](assets/img/linux-desktop/tails.svg){ .twemoji } [Tails (Live Boot)](desktop.md#tails)
-
-</div>
+[![Qubes OS logo](assets/img/qubes/qubes_os.svg){ .twemoji } Qubes OS (Xen VM Distribution)](desktop.md#qubes-os){.md-button}
+[![Fedora logo](assets/img/linux-desktop/fedora-workstation.svg){ .twemoji } Fedora Workstation](desktop.md#fedora-workstation){.md-button}
+[![openSUSE Tumbleweed logo](assets/img/linux-desktop/opensuse-tumbleweed.svg){ .twemoji } OpenSUSE Tumbleweed](desktop.md#opensuse-tumbleweed){.md-button}
+[![Arch logo](assets/img/linux-desktop/archlinux.svg){ .twemoji } Arch Linux](desktop.md#arch-linux){.md-button}
+[![Fedora Silverblue logo](assets/img/linux-desktop/fedora-silverblue.svg){ .twemoji } Fedora Silverblue & Kinoite](desktop.md#fedora-silverblue){.md-button}
+[![nixOS logo](assets/img/linux-desktop/nixos.svg){ .twemoji } NixOS](desktop.md#nixos){.md-button}
+[![Whonix logo](assets/img/linux-desktop/whonix.svg){ .twemoji } Whonix (Tor)](desktop.md#whonix){.md-button}
+[![Tails logo](assets/img/linux-desktop/tails.svg){ .twemoji } Tails (Live Boot)](desktop.md#tails){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](desktop.md)
 
 ### Router Firmware
 
-<div class="grid cards" markdown>
-
-- ![OpenWrt logo](assets/img/router/openwrt.svg#only-light){ .twemoji }![OpenWrt logo](assets/img/router/openwrt-dark.svg#only-dark){ .twemoji } [OpenWrt](router.md#openwrt)
-- ![OPNsense logo](assets/img/router/opnsense.svg){ .twemoji } [OPNsense](router.md#opnsense)
-
-</div>
+[![OpenWrt logo](assets/img/router/openwrt.svg#only-light){ .twemoji }![OpenWrt logo](assets/img/router/openwrt-dark.svg#only-dark){ .twemoji } OpenWrt](router.md#openwrt){.md-button}
+[![OPNsense logo](assets/img/router/opnsense.svg){ .twemoji } OPNsense](router.md#opnsense){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](router.md)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -39,7 +39,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Mobile Web Browsers
 
-[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave (Android)](mobile-browsers.md#brave){md.button}
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave (Android)](mobile-browsers.md#brave){.md-button}
 [![Safari logo](assets/img/browsers/safari.svg){ .twemoji } Safari (iOS)](mobile-browsers.md#safari){.md-button}
 
 [Learn more :material-arrow-right-drop-circle:](mobile-browsers.md)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,7 +29,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 ## Desktop Web Browsers
 
-<div class="grid" markdown>
+<div class="grid cards" markdown>
 
 - ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser)
 - ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,9 +31,12 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid" markdown>
 
-[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .card }
-[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .card }
-[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .card }
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser)
+{ .card }
+[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox)
+{ .card }
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave)
+{ .card }
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards annotate" markdown>
 
-- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser)
+[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser)
 - ![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } [Orbot (Smartphone Tor Proxy)](tor.md#orbot)
 - ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } [Snowflake](tor.md#snowflake) (1)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,9 +17,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards annotate" markdown>
 
-[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser{ .card }](tor.md#tor-browser)
-- ![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } [Orbot (Smartphone Tor Proxy)](tor.md#orbot)
-- ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } [Snowflake](tor.md#snowflake) (1)
+[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button }
+[![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } Orbot (Smartphone Tor Proxy)](tor.md#orbot){ .md-button }
+[![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } Snowflake](tor.md#snowflake){.md-button} (1)
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -18,6 +18,7 @@ For more details about each project, why they were chosen, and additional tips o
 [![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser){ .md-button }
 [![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } Orbot (Smartphone Tor Proxy)](tor.md#orbot){ .md-button }
 [![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } Snowflake](tor.md#snowflake){.md-button} (1)
+{.annotate}
 
 1. Snowflake does not increase privacy, however it allows you to easily contribute to the Tor network and help people in censored networks achieve better privacy.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,9 +31,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid" markdown>
 
-[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser{ .card }](desktop-browsers.md#mullvad-browser)
-[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox{ .card }](desktop-browsers.md#firefox)
-[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave{ .card }](desktop-browsers.md#brave)
+[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .card }
+[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .card }
+[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .card }
 
 </div>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid cards annotate" markdown>
 
-[![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } Tor Browser](tor.md#tor-browser)
+- ![Tor Browser logo](assets/img/browsers/tor.svg){ .twemoji } [Tor Browser](tor.md#tor-browser)
 - ![Orbot logo](assets/img/self-contained-networks/orbot.svg){ .twemoji } [Orbot (Smartphone Tor Proxy)](tor.md#orbot)
 - ![Snowflake logo](assets/img/browsers/snowflake.svg#only-light){ .twemoji }![Snowflake logo](assets/img/browsers/snowflake-dark.svg#only-dark){ .twemoji } [Snowflake](tor.md#snowflake) (1)
 
@@ -31,9 +31,9 @@ For more details about each project, why they were chosen, and additional tips o
 
 <div class="grid" markdown>
 
-[![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } Mullvad Browser](desktop-browsers.md#mullvad-browser){ .md-button }
-[![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } Firefox](desktop-browsers.md#firefox){ .md-button }
-[![Brave logo](assets/img/browsers/brave.svg){ .twemoji } Brave](desktop-browsers.md#brave){ .md-button }
+- ![Mullvad Browser logo](assets/img/browsers/mullvad_browser.svg){ .twemoji } [Mullvad Browser](desktop-browsers.md#mullvad-browser)
+- ![Firefox logo](assets/img/browsers/firefox.svg){ .twemoji } [Firefox](desktop-browsers.md#firefox)
+- ![Brave logo](assets/img/browsers/brave.svg){ .twemoji } [Brave](desktop-browsers.md#brave)
 
 </div>
 


### PR DESCRIPTION
Changes proposed in this PR:

- Make it so the buttons on the tools page will send you to the desired page instead of just the text

closes #2202 
<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
