### PR TITLE
Fix Italian flag icon

### DIFF
--- a/config/mkdocs-common.yml
+++ b/config/mkdocs-common.yml
@@ -53,7 +53,7 @@ extra:
     - name: Italian
       link: /it/
       lang: it
-      icon: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f1ee-1f1ea.svg
+      icon: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f1ee-1f1f9.svg
     - name: Nederlands
       link: /nl/
       lang: nl


### PR DESCRIPTION
Changes proposed in this PR:

- The italian flag icon was irish. I only noticed it on this page, I do not know if it occurs on others pages.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [ x] I have disclosed any relevant conflicts of interest in my post.
- [ x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [ x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [ x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
