### PR TITLE
Fix inaccurate info in macOS

### DIFF
--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -133,20 +133,6 @@ On older Intel-based Mac computers, FileVault is the only form of disk encryptio
 
 - [x] Click **Turn On**
 
-### MAC Address Randomization
-
-Unlike iOS, macOS doesn't give you an option to randomize your MAC address in the settings, so you'll need to do it with a command or a script.
-
-You open up your Terminal and enter this command to randomize your MAC address:
-
-``` zsh
-openssl rand -hex 6 | sed 's/\(..\)/\1:/g; s/.$//' | xargs sudo ifconfig en1 ether 
-```
-
-en1 is the name of the interface you're changing the MAC address for. This might not be the right one on every Mac, so to check you can hold the option key and click the Wi-Fi symbol at the top right of your screen.
-
-This will be reset on reboot.
-
 ## Security Protections
 
 macOS employs defense in depth by relying on multiple layers of software and hardware-based protections, with different properties. This ensures that a failure in one layer does not compromise the system's overall security.

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -129,12 +129,6 @@ macOS employs defense in depth by relying on multiple layers of software and har
 
     macOS allows you to install beta updates. These are unstable and may come with extra telemetry since they're for testing purposes. Because of this, we recommend you avoid beta software in general.
 
-### App Revocation Checks
-
-macOS performs online OCSP checks using HTTPS encryption when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.
-
-We recommend against blocking these checks.
-
 #### Signed System Volume
 
 macOS's system components are protected in a read-only signed system volume, meaning that neither you nor malware can alter important system files.
@@ -148,6 +142,12 @@ macOS sets certain security restrictions that can't be overridden. These are cal
 System Integrity Protection makes critical file locations read-only to protect against modification from malicious code. This is on top of the hardware-based Kernel Integrity Protection that keeps the kernel from being modified in-memory.
 
 #### Application Security
+
+### App Revocation Checks
+
+macOS performs online OCSP checks using HTTPS encryption when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.
+
+We recommend against blocking these checks.
 
 ##### App Sandbox
 

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -11,10 +11,6 @@ Older Intel-based Macs and Hackintoshes do not support all the security features
 
 There are a few notable privacy concerns with macOS that you should consider. These pertain to the operating system itself, and not Apple's other apps and services.
 
-### Activation Lock
-
-Brand new Apple silicon devices can be set up without an internet connection. However, recovering or resetting your Mac will **require** an internet connection to Apple's servers to check against the Activation Lock database of lost or stolen devices.
-
 ### App Revocation Checks
 
 macOS performs online checks when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -27,8 +27,6 @@ However, exploits in protective utilities like `sudo` have been [discovered in t
 
 If you do use a second account, it is not strictly required to ever log in to your original Administrator account from the macOS login screen. When you are doing something as a Standard user which requires Administrator permissions, the system should prompt you for authentication, where you can enter your Administrator credentials as your Standard user on a one-time basis. Apple provides [guidance](https://support.apple.com/HT203998) on hiding your Administrator account if you prefer to only see a single account on your login screen.
 
-Alternatively, you can use a utility like [macOS Enterprise Privileges](https://github.com/SAP/macOS-enterprise-privileges) to escalate to Administrator rights on-demand, but this may be vulnerable to some undiscovered exploit, like all software-based protections.
-
 ### iCloud
 
 The majority of privacy and security concerns with Apple products are related to their *cloud services*, not their hardware or software. When you use Apple services like iCloud, most of your information is stored on their servers and secured with keys *which Apple has access to* by default. This level of access has occasionally been abused by law enforcement to get around the fact that your data is otherwise securely encrypted on your device, and of course Apple is vulnerable to data breaches like any other company.

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -159,11 +159,7 @@ System Integrity Protection makes critical file locations read-only to protect a
 
 ##### App Sandbox
 
-macOS apps downloaded from the App Store are required to be sandboxed usng the [App Sandbox](https://developer.apple.com/documentation/security/app_sandbox).
-
-!!! warning
-
-    Software downloaded from outside the official App Store is not required to be sandboxed. You should avoid non-App Store software as much as possible.
+macOS apps downloaded from the App Store are required to use the [App Sandbox](https://developer.apple.com/documentation/security/app_sandbox). You should avoid non-App Store software as much as possible.
 
 ##### Antivirus
 

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -7,16 +7,6 @@ description: macOS is Apple's desktop operating system that works with their har
 
 Older Intel-based Macs and Hackintoshes do not support all the security features that macOS offers. To enhance data security, we recommend using a newer Mac with [Apple silicon](https://support.apple.com/en-us/HT211814).
 
-## Privacy Notes
-
-There are a few notable privacy concerns with macOS that you should consider. These pertain to the operating system itself, and not Apple's other apps and services.
-
-### App Revocation Checks
-
-macOS performs online OCSP checks using HTTPS encryption when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.
-
-We recommend against blocking these checks.
-
 ## Recommended Configuration
 
 Your account when you first set up your Mac will be an Administrator account, which has higher privileges than a Standard user account. macOS has a number of protections which prevent malware and other programs from abusing your Administrator privileges, so it is generally safe to use this account.
@@ -138,6 +128,12 @@ macOS employs defense in depth by relying on multiple layers of software and har
 !!! warning
 
     macOS allows you to install beta updates. These are unstable and may come with extra telemetry since they're for testing purposes. Because of this, we recommend you avoid beta software in general.
+
+### App Revocation Checks
+
+macOS performs online OCSP checks using HTTPS encryption when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.
+
+We recommend against blocking these checks.
 
 #### Signed System Volume
 

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -115,9 +115,9 @@ Decide whether you want personalized ads based on your usage.
 
 ##### Security
 
-Apps from the App Store are subject to stricter security guidelines, such as stricter sandboxing. If the only apps you need are available from the App Store, change the **Allow applications downloaded from** setting to **App Store** to prevent accidentally running other apps. This is a good option particularly if you are configuring a machine for other, less technical users such as children.
+Apps from the App Store are subject to stricter security guidelines, such as stricter sandboxing. If the only apps you need are available from the App Store, change the **Allow applications downloaded from** setting to **App Store**.
 
-If you choose to also allow applications from identified developers, be careful about the apps you run and where you obtain them.
+Be aware that this setting can be trivially bypassed; any random binary can be run whether this setting is enabled or not.
 
 ##### FileVault
 

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -13,11 +13,9 @@ There are a few notable privacy concerns with macOS that you should consider. Th
 
 ### App Revocation Checks
 
-macOS performs online checks when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.
+macOS performs online OCSP checks using HTTPS encryption when you open an app to verify whether an app contains known malware, and whether the developer’s signing certificate is revoked.
 
-Previously, these checks were performed via an unencrypted OCSP protocol which could leak information about the apps you ran to your network. Apple upgraded their OCSP service to use HTTPS encryption in 2021, and [posted information](https://support.apple.com/HT202491) about their logging policy for this service. They additionally promised to add a mechanism for people to opt-out of this online check, but this has not been added to macOS as of July 2023.
-
-While you [can](https://eclecticlight.co/2021/02/23/how-to-run-apps-in-private/) manually opt out of this check relatively easily, we recommend against doing so unless you would be badly compromised by the revocation checks performed by macOS, because they serve an important role in ensuring compromised apps are blocked from running.
+We recommend against blocking these checks.
 
 ## Recommended Configuration
 

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -163,10 +163,7 @@ macOS apps downloaded from the App Store are required to use the [App Sandbox](h
 
 ##### Antivirus
 
-macOS comes with two forms of malware defense:
-
-1. Protection against launching malware in the first place is provided by the App Store's review process for App Store applications, or *Notarization* (part of *Gatekeeper*), a process where third-party apps are scanned for known malware by Apple before they are allowed to run.
-2. Protection against other malware and remediation from existing malware on your system is provided by *XProtect*, a more traditional antivirus software built-in to macOS.
+Protection against malware on your system is provided by *XProtect*, an antivirus program built-in to macOS.
 
 We recommend against installing third-party antivirus software as they typically do not have the system-level access required to properly function anyways, because of Apple's limitations on third-party apps, and because granting the high levels of access they do ask for often poses an even greater security and privacy risk to your computer.
 

--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -99,12 +99,6 @@ Decide whether you want personalized ads based on your usage.
 
 - [ ] Uncheck **Personalized Ads**
 
-##### Security
-
-Apps from the App Store are subject to stricter security guidelines, such as stricter sandboxing. If the only apps you need are available from the App Store, change the **Allow applications downloaded from** setting to **App Store**.
-
-Be aware that this setting can be trivially bypassed; any random binary can be run whether this setting is enabled or not.
-
 ##### FileVault
 
 On modern devices with a Secure Enclave (Apple T2 Security Chip, Apple silicon), your data is always encrypted, but is decrypted automatically by a hardware key if your device doesn't detect it's been tampered with. Enabling FileVault additionally requires your password to decrypt your data, greatly improving security, especially when powered off or before the first login after powering on.


### PR DESCRIPTION
Changes proposed in this PR:

- Remove activation lock
- Change "Allow Applications Downloaded from" setting to be more accurate
- Remove MAC address randomization
- More accurate wording for App Sandbox
- Remove notarization from antivirus setting as it provides very little protection

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
