### PR TITLE
Improve SSH commit signing instructions

### DIFF
--- a/docs/meta/git-recommendations.md
+++ b/docs/meta/git-recommendations.md
@@ -13,7 +13,7 @@ You can use an existing SSH key for signing, or [create a new one](https://docs.
    git config --global gpg.format ssh
    git config --global tag.gpgSign true
    ```
-2. Set your SSH key for signing in Git with the following command, substituting `/PATH/TO/KEY.PUB` with the path to the public key you'd like to use, e.g. `/home/user/.ssh/id_ed25519.pub`:
+2. Set your SSH key for signing in Git with the following command, substituting `/PATH/TO/.SSH/KEY.PUB` with the path to the public key you'd like to use, e.g. `/home/user/.ssh/id_ed25519.pub`:
    ```
    git config --global user.signingkey /PATH/TO/.SSH/KEY.PUB
    ```

--- a/docs/meta/git-recommendations.md
+++ b/docs/meta/git-recommendations.md
@@ -16,11 +16,19 @@ You can use an existing SSH key for signing, or [create a new one](https://docs.
 2. Copy your SSH public key to your clipboard, for example:
    ```
    pbcopy < ~/.ssh/id_ed25519.pub
-    # Copies the contents of the id_ed25519.pub file to your clipboard
+   # Copies the contents of the id_ed25519.pub file to your clipboard
+   
+   sudo apt install xclip
+   xclip -i ~/.ssh/id_ed25519.pub
+   # For WSL users without pbcopy
    ```
 3. Set your SSH key for signing in Git with the following command, replacing the last string in quotes with the public key in your clipboard:
    ```
    git config --global user.signingkey 'ssh-ed25519 AAAAC3(...) user@example.com'
+   # Set the SSH key as the default for signing globally
+   
+   git config --global user.signingkey "$(xclip -o)"
+   # Same result but for Xclip
    ```
 
 Ensure you [add your SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account#adding-a-new-ssh-key-to-your-account) **as a Signing Key** (as opposed to or in addition to as an Authentication Key).

--- a/docs/meta/git-recommendations.md
+++ b/docs/meta/git-recommendations.md
@@ -13,22 +13,9 @@ You can use an existing SSH key for signing, or [create a new one](https://docs.
    git config --global gpg.format ssh
    git config --global tag.gpgSign true
    ```
-2. Copy your SSH public key to your clipboard, for example:
+2. Set your SSH key for signing in Git with the following command, substituting `/PATH/TO/KEY.PUB` with the path to the public key you'd like to use, e.g. `/home/user/.ssh/id_ed25519.pub`:
    ```
-   pbcopy < ~/.ssh/id_ed25519.pub
-   # Copies the contents of the id_ed25519.pub file to your clipboard
-   
-   sudo apt install xclip
-   xclip -i ~/.ssh/id_ed25519.pub
-   # For WSL users without pbcopy
-   ```
-3. Set your SSH key for signing in Git with the following command, replacing the last string in quotes with the public key in your clipboard:
-   ```
-   git config --global user.signingkey 'ssh-ed25519 AAAAC3(...) user@example.com'
-   # Set the SSH key as the default for signing globally
-   
-   git config --global user.signingkey "$(xclip -o)"
-   # Same result but for Xclip
+   git config --global user.signingkey /PATH/TO/.SSH/KEY.PUB
    ```
 
 Ensure you [add your SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account#adding-a-new-ssh-key-to-your-account) **as a Signing Key** (as opposed to or in addition to as an Authentication Key).


### PR DESCRIPTION
Changes proposed in this PR:

- Add alternative for SSH signing in git for WSL

This PR is to suggest a WSL method for assigning a SSH git key using the `xclip` command, rather than `pbcopy`.
Saves people time figuring out Ubuntu doesn't have the `pbcopy` package, and is pretty straightforward.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
