### PR TITLE
Capitalize Mac OS overview page title.

### DIFF
--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -1,5 +1,5 @@
 ---
-title: macOS Overview
+title: MacOS Overview
 icon: material/apple-finder
 description: macOS is Apple's desktop operating system that works with their hardware to provide strong security.
 ---


### PR DESCRIPTION
This makes the os overview section more uniform.