### PR TITLE
Switch hosting provider to Cloudflare Pages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,160 @@
+# Copyright (c) 2023 Jonah Aragon <jonah@triplebit.net>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+name: 🌩️ Deploy Preview to Cloudflare
+
+on: [ push, delete, create ]
+
+# Allow one concurrent deployment
+concurrency:
+  group: "cloudflare-preview"
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: 3.8
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [en, es, fr, he, it, nl, ru, zh-Hant]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          ssh-key: ${{ secrets.ACTIONS_SSH_KEY }}
+          submodules: 'true'
+
+      - name: Python setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          cache: 'pipenv'
+      
+      - name: Cache files
+        uses: actions/cache@v3.3.2
+        with:
+          key: ${{ github.ref }}
+          path: .cache
+
+      - name: Install Python dependencies
+        run: |
+          pip install pipenv
+          pipenv install
+          sudo apt install pngquant
+
+      - name: Build website
+
+        # FOR TESTING/DEBUG ONLY:
+        continue-on-error: true
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARDS: true
+        run: |
+          git clone https://github.com/privacyguides/i18n i18n-download
+          cp -rl i18n-download/i18n .
+          cp -rl i18n-download/includes .
+          cp -rl i18n-download/theme .
+          pipenv run mkdocs build --config-file config/mkdocs.${{ matrix.language }}.yml
+          cp -r static/* site/
+          pipenv run mkdocs --version
+      
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: site-${{ matrix.language }}
+          path: site/${{ matrix.language }}
+      
+  deploy:
+    needs: build
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          ssh-key: ${{ secrets.ACTIONS_SSH_KEY }}
+          submodules: 'false'
+
+      - name: Download en
+        uses: actions/download-artifact@v3
+        with:
+          name: site-en
+          path: site/en
+
+      - name: Download es
+        uses: actions/download-artifact@v3
+        with:
+          name: site-es
+          path: site/es
+      
+      - name: Download fr
+        uses: actions/download-artifact@v3
+        with:
+          name: site-fr
+          path: site/fr
+
+      - name: Download he
+        uses: actions/download-artifact@v3
+        with:
+          name: site-he
+          path: site/he
+
+      - name: Download it
+        uses: actions/download-artifact@v3
+        with:
+          name: site-it
+          path: site/it
+      
+      - name: Download nl
+        uses: actions/download-artifact@v3
+        with:
+          name: site-nl
+          path: site/nl
+
+      - name: Download ru
+        uses: actions/download-artifact@v3
+        with:
+          name: site-ru
+          path: site/ru
+
+      - name: Download zh-Hant
+        uses: actions/download-artifact@v3
+        with:
+          name: site-zh-Hant
+          path: site/zh-Hant
+
+      - run: |
+          ls -la site/
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: preview-privacyguides-org
+          directory: site

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -65,10 +65,6 @@ jobs:
           sudo apt install pngquant
 
       - name: Build website
-
-        # FOR TESTING/DEBUG ONLY:
-        continue-on-error: true
-
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARDS: true
@@ -81,11 +77,11 @@ jobs:
           cp -r static/* site/
           pipenv run mkdocs --version
       
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+      - name: Cache build output
+        uses: actions/cache/save@v3
         with:
-          name: site-${{ matrix.language }}
           path: site/${{ matrix.language }}
+          key: build-${{ matrix.language }}-${{ github.sha }}
       
   deploy:
     needs: build
@@ -101,54 +97,63 @@ jobs:
           submodules: 'false'
 
       - name: Download en
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-en
+          key: build-en-${{ github.sha }}
           path: site/en
+          fail-on-cache-miss: true
 
       - name: Download es
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-es
+          key: build-es-${{ github.sha }}
           path: site/es
+          fail-on-cache-miss: true
       
       - name: Download fr
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-fr
+          key: build-fr-${{ github.sha }}
           path: site/fr
+          fail-on-cache-miss: true
 
       - name: Download he
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-he
+          key: build-he-${{ github.sha }}
           path: site/he
+          fail-on-cache-miss: true
 
       - name: Download it
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-it
+          key: build-it-${{ github.sha }}
           path: site/it
+          fail-on-cache-miss: true
       
       - name: Download nl
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-nl
+          key: build-nl-${{ github.sha }}
           path: site/nl
+          fail-on-cache-miss: true
 
       - name: Download ru
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-ru
+          key: build-ru-${{ github.sha }}
           path: site/ru
+          fail-on-cache-miss: true
 
       - name: Download zh-Hant
-        uses: actions/download-artifact@v3
+        uses: actions/cache/restore@v3
         with:
-          name: site-zh-Hant
+          key: build-zh-Hant-${{ github.sha }}
           path: site/zh-Hant
+          fail-on-cache-miss: true
 
       - run: |
+          cp -r static/* site/
           ls -la site/
 
       - name: Publish to Cloudflare Pages

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,12 +22,6 @@
     publish = "site/"
     command = "mkdocs build --config-file config/mkdocs.en.yml && cp -r static/* site/"
 
-    [context.production]
-        command = "git clone https://github.com/privacyguides/i18n i18n-download && cp -rl i18n-download/i18n . && cp -rl i18n-download/includes . && cp -rl i18n-download/theme . && mkdocs build --config-file config/mkdocs.en.yml && mkdocs build --config-file config/mkdocs.es.yml && mkdocs build --config-file config/mkdocs.fr.yml && mkdocs build --config-file config/mkdocs.he.yml && mkdocs build --config-file config/mkdocs.it.yml && mkdocs build --config-file config/mkdocs.nl.yml && mkdocs build --config-file config/mkdocs.zh-Hant.yml && mkdocs build --config-file config/mkdocs.ru.yml && cp -r static/* site/"
-
-    [context.branch-deploy]
-        command = "crowdin download && for i in config/mkdocs.*.yml; do mkdocs build --config-file $i; done && cp -r static/* site/"
-
 [[headers]]
   for = "/*"
   [headers.values]
@@ -35,54 +29,4 @@
     X-XSS-Protection = "0"
     X-Content-Type-Options = "nosniff"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
-    Content-Security-Policy = "default-src 'none'; script-src https://www.privacyguides.org https://api.privacyguides.net 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src data: 'self'; connect-src https://api.github.com https://*.privacyguides.net 'self'; frame-src https://*.privacyguides.net; frame-ancestors 'none'"
-
-[[headers]]
-  for = "/:lang/about/donate/"
-  [headers.values]
-    Content-Security-Policy = "default-src 'none'; script-src https://opencollective.com https://www.privacyguides.org https://api.privacyguides.net 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src https://opencollective.com data: 'self'; connect-src https://api.github.com https://*.privacyguides.net 'self'; frame-src https://opencollective.com; frame-ancestors 'none'"
-
-[[headers]]
-  for = "/:lang/tor/"
-  [headers.values]
-    Content-Security-Policy = "default-src 'none'; script-src https://www.privacyguides.org https://api.privacyguides.net 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src data: 'self'; connect-src https://api.github.com https://*.privacyguides.net 'self'; frame-src https://snowflake.torproject.org; frame-ancestors 'none'"
-
-[[redirects]]
-    from = "/es/*"
-    to = "/i18n/404.es.html"
-    status = 404
-
-[[redirects]]
-    from = "/fr/*"
-    to = "/i18n/404.fr.html"
-    status = 404
-
-[[redirects]]
-    from = "/he/*"
-    to = "/i18n/404.he.html"
-    status = 404
-
-[[redirects]]
-    from = "/it/*"
-    to = "/i18n/404.it.html"
-    status = 404
-
-[[redirects]]
-    from = "/nl/*"
-    to = "/i18n/404.nl.html"
-    status = 404
-
-[[redirects]]
-    from = "/zh-hant/*"
-    to = "/i18n/404.zh-Hant.html"
-    status = 404
-
-[[redirects]]
-    from = "/ru/*"
-    to = "/i18n/404.ru.html"
-    status = 404
-
-[[redirects]]
-    from = "/*"
-    to = "/i18n/404.en.html"
-    status = 404
+    Content-Security-Policy = "default-src 'none'; script-src https://www.privacyguides.org https://opencollective.com 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src https://opencollective.com data: 'self'; connect-src https://api.github.com https://*.privacyguides.net 'self'; frame-src https://opencollective.com https://snowflake.torproject.org https://*.privacyguides.net; frame-ancestors 'none'"

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 0
+  X-Content-Type-Options: nosniff
+  Content-Security-Policy: default-src 'none'; script-src https://www.privacyguides.org https://opencollective.com 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src https://opencollective.com data: 'self'; connect-src https://api.github.com https://*.privacyguides.net 'self'; frame-src https://opencollective.com https://snowflake.torproject.org https://*.privacyguides.net; frame-ancestors 'none'

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,87 +1,22 @@
-# Copyright (c) 2023 Jonah Aragon <jonah@triplebit.net>
+/ /en/
 
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-
-/  /en/       302  Language=en
-/  /es/       302  Language=es
-/  /fr/       302  Language=fr
-/  /he/       302  Language=he
-/  /it/       302  Language=it
-/  /nl/       302  Language=nl
-/  /zh-hant/  302  Language=zh-Hant
-/  /ru/       302  Language=ru
-/  /en/       302
-
-/.well-known/matrix/* https://matrix.privacyguides.org/.well-known/matrix/:splat 200
 /.well-known/* /well-known/:splat 200
 
 /kb /en/basics/why-privacy-matters/
 /:lang/kb /:lang/basics/why-privacy-matters/
+/kb/ /en/basics/why-privacy-matters/
+/:lang/kb/ /:lang/basics/why-privacy-matters/
 
 /coc /en/CODE_OF_CONDUCT/
 /license https://github.com/privacyguides/privacyguides.org/tree/main/README.md#license
 
-/team /en/about/
-/browsers /en/desktop-browsers/
-/blog https://blog.privacyguides.org
-/basics/dns-overview /en/advanced/dns-overview/
-/basics/tor-overview /en/advanced/tor-overview/
-/real-time-communication/communication-network-types /en/advanced/communication-network-types
-/advanced/real-time-communication /en/advanced/communication-network-types
-/android/overview /en/os/android-overview/
-/linux-desktop/overview /en/os/linux-overview/
-/android/grapheneos-vs-calyxos https://blog.privacyguides.org/2022/04/21/grapheneos-or-calyxos/
-/ios/configuration https://blog.privacyguides.org/2022/10/22/ios-configuration-guide/
-/linux-desktop/hardening https://blog.privacyguides.org/2022/04/22/linux-system-hardening/
-/linux-desktop/sandboxing https://blog.privacyguides.org/2022/04/22/linux-application-sandboxing/
-/advanced/signal-configuration-hardening https://blog.privacyguides.org/2022/07/07/signal-configuration-and-hardening/
-/real-time-communication/signal-configuration-hardening https://blog.privacyguides.org/2022/07/07/signal-configuration-and-hardening/
-/advanced/integrating-metadata-removal https://blog.privacyguides.org/2022/04/09/integrating-metadata-removal/
-/advanced/erasing-data https://blog.privacyguides.org/2022/05/25/secure-data-erasure/
-/operating-systems /en/desktop/
-/threat-modeling /en/basics/threat-modeling/
-/self-contained-networks /en/tor/
-/privacy-policy /en/about/privacy-policy/
-/metadata-removal-tools /en/data-redaction/
-/basics /en/kb
-/software/file-encryption /en/encryption/
-/providers /en/tools/#service-providers
-/software/calendar-contacts /en/calendar/
-/calendar-contacts /en/calendar/
-/software/metadata-removal-tools /en/data-redaction/
-/contact /en/about/
-/welcome-to-privacy-guides https://blog.privacyguides.org/2021/09/14/welcome-to-privacy-guides/
-/software/email /en/email-clients/
-/providers/paste /en/tools/
-/blog/2019/10/05/understanding-vpns https://www.jonaharagon.com/posts/understanding-vpns/
-/terms-and-notices /en/about/notices/
-/software/networks /en/tor/
-/social-news-aggregator /en/news-aggregators/
-/basics/erasing-data https://blog.privacyguides.org/2022/05/25/secure-data-erasure/
-/linux-desktop /en/desktop/
+/team /en/about/ 301
+/browsers /en/desktop-browsers/ 301
+/blog https://blog.privacyguides.org 301
 
-/providers/:slug /en/:slug/
-/software/:slug /en/:slug/
-/blog/* https://blog.privacyguides.org/:splat
-/assets/* /en/assets/:splat
+/blog/* https://blog.privacyguides.org/:splat 301
+/assets/* /en/assets/:splat 301
 
-/:slug/ /en/:slug/
 /about/:slug/ /en/about/:slug/
 /advanced/:slug/ /en/advanced/:slug/
 /basics/:slug/ /en/basics/:slug/

--- a/static/well-known/matrix/client
+++ b/static/well-known/matrix/client
@@ -1,0 +1,5 @@
+{
+    "m.homeserver": {
+        "base_url": "https://matrix.privacyguides.org"
+    }
+}

--- a/static/well-known/matrix/server
+++ b/static/well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+    "m.server": "matrix.privacyguides.org:8448"
+}

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -104,7 +104,7 @@
               {% for alt in config.extra.alternate %}
                 <li class="md-select__item">
                   <a
-                    href="{{ alt.link | url }}"
+                    href="{{ "/" ~ alt.lang ~ "/" ~ page.url }}"
                     hreflang="{{ alt.lang }}"
                     class="md-select__link"
                   >


### PR DESCRIPTION
Just exploring this option, this PR would let us move the main website hosting from Netlify to having it built on GitHub Actions and hosted on Cloudflare Pages.

There's a few reasons we might want to do this:

1. Netlify doesn't allow multiple users to access it (well, it does but it's mega expensive). Both @dngray and I have access to our Cloudflare account, and we could grant very granular access to other people as needed for free.
2. Any team member could re-attempt and troubleshoot a failed site build in the [Actions](https://github.com/privacyguides/privacyguides.org/actions) tab on GitHub, instead of needing me to log in to Netlify.
3. Netlify analytics is an additional $9/month, and we are considering using it because of #2305 
4. Benefiting from ECH on Cloudflare's platform might legitimately outweigh the privacy concerns people have with Cloudflare, if ECH is adopted by major browsers.

Cloudflare Pages is *not* as nice as Netlify in some respects:

1. The redirect options are way worse, we can't redirect by browser language or country code, so everyone visiting privacyguides.org would just default to `/en/` unless they manually select their language using the flag on the site.

We would continue using Netlify for PR Previews only, because there are security issues with creating PR Previews with GitHub Actions, and the alternative Cloudflare Pages app we could normally use does not build our site properly.

---

Test preview: https://jonaharagon-cloudflare-pages.preview-privacyguides-org.pages.dev/ - I think everything functions as intended here...