### PR TITLE
AdGuard DNS supports ECS as of v0.3.1

### DIFF
--- a/docs/dns.md
+++ b/docs/dns.md
@@ -13,7 +13,7 @@ Encrypted DNS with third-party servers should only be used to get around basic [
 
 | DNS Provider | Privacy Policy | Protocols | Logging | ECS | Filtering |
 | ------------ | -------------- | --------- | ------- | --- | --------- |
-| [**AdGuard**](https://adguard.com/en/adguard-dns/overview.html) | [:octicons-link-external-24:](https://adguard.com/en/privacy/dns.html) | Cleartext <br> DoH/3 <br> DoT <br> DNSCrypt | Some[^1] | No | Based on personal configuration. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/AdguardTeam/AdGuardDNS)
+| [**AdGuard**](https://adguard.com/en/adguard-dns/overview.html) | [:octicons-link-external-24:](https://adguard.com/en/privacy/dns.html) | Cleartext <br> DoH/3 <br> DoT <br> DNSCrypt | Some[^1] | Yes | Based on personal configuration. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/AdguardTeam/AdGuardDNS)
 | [**Cloudflare**](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/) | [:octicons-link-external-24:](https://developers.cloudflare.com/1.1.1.1/privacy/public-dns-resolver/) | Cleartext <br> DoH/3 <br> DoT | Some[^2] | No | Based on personal configuration.|
 | [**Control D**](https://controld.com/free-dns) | [:octicons-link-external-24:](https://controld.com/privacy) | Cleartext <br> DoH/3 <br> DoT <br> DoQ| Optional[^3] | No | Based on personal configuration. |
 | [**Mullvad**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls) | [:octicons-link-external-24:](https://mullvad.net/en/help/no-logging-data-policy/) | DoH <br> DoT | No[^4] | No | Based on personal configuration. Filter list being used can be found here. [:octicons-link-external-24:](https://github.com/mullvad/dns-adblock)


### PR DESCRIPTION
Changes proposed in this PR:

-  AdGuard DNS has supported ECS since v0.3.1.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
