### PR TITLE
Rebranding 'Immutable Distributions'

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -70,7 +70,9 @@ Being a DIY distribution, you are [expected to set up and maintain](os/linux-ove
 
 A large portion of [Arch Linux’s packages](https://reproducible.archlinux.org) are [reproducible](https://reproducible-builds.org).
 
-## Immutable Distributions
+## Atomic Distributions
+
+**Atomic distributions** (sometimes also referred to as **immutable distributions**) are operating systems which handle package installation and updates by layering changes atop your core system image, rather than by directly modifying the system. This has advantages including increased stability and the ability to easily rollback updates. See [*Traditional vs. Atomic Updates*](os/linux-overview.md#traditional-vs-atomic-updates) for more info.
 
 ### Fedora Atomic Desktops
 
@@ -78,7 +80,7 @@ A large portion of [Arch Linux’s packages](https://reproducible.archlinux.org)
 
 ![Fedora logo](assets/img/linux-desktop/fedora.svg){ align=right }
 
-**Fedora Atomic Desktops** are the immutable variants of Fedora with a strong focus on containerized workflows and Flatpak for desktop applications. All of these variants follow the same release schedule as Fedora Workstation, benefiting from the same fast updates and staying very close to upstream.
+**Fedora Atomic Desktops** are variants of Fedora which use the `rpm-ostree` package manager and have a strong focus on containerized workflows and Flatpak for desktop applications. All of these variants follow the same release schedule as Fedora Workstation, benefiting from the same fast updates and staying very close to upstream.
 
 [:octicons-home-16: Homepage](https://fedoraproject.org/atomic-desktops/){ .md-button .md-button--primary }
 [:octicons-heart-16:](https://whatcanidoforfedora.org/){ .card-link title=Contribute }

--- a/docs/os/linux-overview.md
+++ b/docs/os/linux-overview.md
@@ -57,7 +57,7 @@ Atomic updating distributions apply updates in full or not at all. Typically, tr
 
 A transactional update system creates a snapshot that is made before and after an update is applied. If an update fails at any time (perhaps due to a power failure), the update can be easily rolled back to a “last known good state."
 
-The Atomic update method is used for immutable distributions like Silverblue, Tumbleweed, and NixOS and can achieve reliability with this model. [Adam Šamalík](https://twitter.com/adsamalik) provided a presentation on how `rpm-ostree` works with Silverblue:
+The Atomic update method is used for [distributions](../desktop.md#atomic-distributions) like Silverblue, Tumbleweed, and NixOS and can achieve reliability with this model. [Adam Šamalík](https://twitter.com/adsamalik) provided a presentation on how `rpm-ostree` works with Silverblue:
 
 <div class="yt-embed">
   <iframe width="560" height="315" src="https://invidious.privacyguides.net/embed/-hpV5l-gJnQ?local=true" title="Let's try Fedora Silverblue — an immutable desktop OS! - Adam Šamalik" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
It seems like both distributions in the current 'immutable distributions' category are moving beyond the immutable branding.

Fedora:
> Thirdly, this nice branding term is also a more accurate way of talking about how rpm-ostree works. Fedora Atomic spins are not actually immutable. There are ways to get around the read-only aspects of the implementation even though it is much harder. The nature of the OS, where updates are only implemented when they successfully build and you can rollback or rebase between core host systems, is better described by atomicity than immutability. Atomic is also how many of the contributors who work on rpm-ostree prefer to talk about it! Rebranding provides an opportunity to change the language surrounding this technology.

Nix:
> NixOS also provides atomic updates; 
(Directly from Privacy Guides)

It's a minor change, but I feel it'd be helpful for the community to be utilizing consistent terminology for different technologies being utilized.

- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).
