### PR TITLE
Update Element organization link

### DIFF
--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -148,7 +148,7 @@ Messages and files shared in private rooms (those which require an invite) are b
 [:octicons-home-16: Homepage](https://element.io/){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://element.io/privacy){ .card-link title="Privacy Policy" }
 [:octicons-info-16:](https://element.io/help){ .card-link title=Documentation}
-[:octicons-code-16:](https://github.com/vector-im){ .card-link title="Source Code" }
+[:octicons-code-16:](https://github.com/element-hq){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
 <summary>Downloads</summary>


### PR DESCRIPTION
Vector-im is the old one, they moved to element-hq

Changes proposed in this PR:

Update Element organization link.

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/en/code_of_conduct/).

