### PR TITLE
Minor: add MacOS/Linux for Cake Wallet

### DIFF
--- a/docs/cryptocurrency.md
+++ b/docs/cryptocurrency.md
@@ -38,7 +38,7 @@ With Monero, outside observers cannot decipher addresses trading Monero, transac
 For optimal privacy, make sure to use a noncustodial wallet where the view key stays on the device. This means that only you will have the ability to spend your funds and see incoming and outgoing transactions. If you use a custodial wallet, the provider can see **everything** you do; if you use a “lightweight” wallet where the provider retains your private view key, the provider can see almost everything you do. Some noncustodial wallets include:
 
 - [Official Monero client](https://getmonero.org/downloads) (Desktop)
-- [Cake Wallet](https://cakewallet.com) (iOS, Android)
+- [Cake Wallet](https://cakewallet.com) (iOS, Android, macOS, Linux BETA)
     - Cake Wallet supports multiple cryptocurrencies. A Monero-only version of Cake Wallet is available at [Monero.com](https://monero.com).
 - [Feather Wallet](https://featherwallet.org) (Desktop)
 - [Monerujo](https://monerujo.io) (Android)


### PR DESCRIPTION
Changes proposed in this PR:

- Add MacOS/linux for Cake Wallet
- You can alternatively change it to `Mobile/Desktop`, but Cake does not support Windows at the time of writing.

- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work.
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/coc).

I previously worked for Cake Wallet but I no longer do. This edit adds 2 platforms that are supported by the app.