### PR TITLE
unsandboxed apps in Mac app store

### DIFF
--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -178,7 +178,7 @@ System Integrity Protection makes critical file locations read-only to protect a
 
 ##### App Sandbox
 
-macOS apps downloaded from the App Store are required to be sandboxed usng the [App Sandbox](https://developer.apple.com/documentation/security/app_sandbox).
+macOS apps submitted to the App Store after June 1, 2012 are required to be sandboxed using the [App Sandbox](https://developer.apple.com/documentation/security/app_sandbox).
 
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>


### PR DESCRIPTION
Changes proposed in this PR:

- modify the application security part for os/macos. Some apps in the Mac app store are not sandboxed. See this [discussion](https://discuss.privacyguides.net/t/til-some-mac-app-store-apps-are-not-sandboxed/17466) for details.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/coc).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
