### PR TITLE
Add Startpage Onion site

### DIFF
--- a/docs/search-engines.md
+++ b/docs/search-engines.md
@@ -88,6 +88,8 @@ When you are using a SearXNG instance, be sure to go read their privacy policy. 
 
 **Startpage** is a private search engine known for serving [Google and Bing](https://support.startpage.com/hc/articles/4522435533844-What-is-the-relationship-between-Startpage-and-your-search-partners-like-Google-and-Microsoft-Bing) search results.  One of Startpage's unique features is the [Anonymous View](https://startpage.com/en/anonymous-view), which puts forth efforts to standardize user activity to make it more difficult to be uniquely identified. The feature can be useful for hiding [some](https://support.startpage.com/hc/articles/4455540212116-The-Anonymous-View-Proxy-technical-details) network and browser properties. Unlike the name suggests, the feature should not be relied upon for anonymity. If you are looking for anonymity, use the [Tor Browser](tor.md#tor-browser) instead.
 
+Startpage can be accessed on the [Tor Browser](tor.md#tor-browser) using their [.onion site](https://support.startpage.com/hc/en-us/articles/24786602537364-Startpage-s-Tor-onion-service).and can be accesed on Tor Safest Level, which disable javascript. It has all features that Starpage.com has, except Anonynous view. 
+
 [:octicons-home-16: Homepage](https://startpage.com){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://startpage.com/en/privacy-policy){ .card-link title="Privacy Policy" }
 [:octicons-info-16:](https://support.startpage.com/hc/categories/4481917470356-Startpage-Search-Engine){ .card-link title=Documentation}
@@ -99,7 +101,8 @@ When you are using a SearXNG instance, be sure to go read their privacy policy. 
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
 
-Startpage regularly limits service access to certain IP addresses, such as IPs reserved for VPNs or Tor. [DuckDuckGo](#duckduckgo) and [Brave Search](#brave-search) are friendlier options if your threat model requires hiding your IP address from the search provider.
+Startpage regularly limits service access to certain IP addresses, such as IPs reserved for VPNs or Tor.
+
 
 </div>
 


### PR DESCRIPTION
Changes proposed in this PR:

I added that Startpage has now an onion site with full feature parity, and removed the note that there is friendlier alternative if you need to hide IP from provider, since you can access it over TOR.
-

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [ X] I have disclosed any relevant conflicts of interest in my post.
- [ X] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [ X] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [X ] I agree to the [Community Code of Conduct](https://www.privacyguides.org/coc).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
