### PR TITLE
Asset cache-busting & i18n string additions

### DIFF
--- a/config/mkdocs-common.yml
+++ b/config/mkdocs-common.yml
@@ -237,10 +237,10 @@ extra:
       ]
     cookies:
       analytics:
-        name: Self-Hosted Analytics
+        name: !ENV [ANALYTICS_COOKIE_UMAMI, "Self-Hosted Analytics"]
         checked: true
       github:
-        name: GitHub API
+        name: !ENV [ANALYTICS_COOKIE_GITHUB, "GitHub API"]
         checked: true
     actions:
       - reject
@@ -293,11 +293,11 @@ theme:
     - search.highlight
 
 extra_css:
-  - assets/stylesheets/extra.css?v=3.17.0
+  - assets/stylesheets/extra.css?v=1
 extra_javascript:
-  - assets/javascripts/randomize-element.js
-  - assets/javascripts/resolution.js
-  - assets/javascripts/feedback.js
+  - assets/javascripts/randomize-element.js?v=1
+  - assets/javascripts/resolution.js?v=1
+  - assets/javascripts/feedback.js?v=1
 
 watch:
   - ../theme

--- a/includes/strings.en.env
+++ b/includes/strings.en.env
@@ -1,5 +1,7 @@
 ANALYTICS_CONSENT_BODY="We collect anonymous statistics about your visits to help us improve the site. We do not track you across other websites. If you disable this, we will not know when you have visited our site. We will save a single cookie in your browser to remember your preference."
 ANALYTICS_CONSENT_TITLE="Contribute anonymous statistics"
+ANALYTICS_COOKIE_GITHUB="GitHub API"
+ANALYTICS_COOKIE_UMAMI="Self-Hosted Analytics"
 ANALYTICS_FEEDBACK_NEGATIVE_NAME="This page could be improved"
 ANALYTICS_FEEDBACK_NEGATIVE_NOTE='Thanks for your feedback! If you want to let us know more, please leave a post on our <a href="https://discuss.privacyguides.net/c/site-development/7" target="_blank" rel="noopener">forum</a>.'
 ANALYTICS_FEEDBACK_POSITIVE_NAME="This page was helpful"


### PR DESCRIPTION
Changes proposed in this PR:

- Change query string on CSS/JS so that browser caches are invalidated, I was seeing bugs on current PG site release 👀 
- Adds some strings to environment variable file for translation
- Fixes linting errors

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<!-- Place an x in the boxes below, like: [x] -->
- [x] I have disclosed any relevant conflicts of interest in my post.
- [x] I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
- [x] I am the sole author of this work. <!-- Do not check this box if you are not -->
- [x] I agree to the [Community Code of Conduct](https://www.privacyguides.org/coc).

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
