### PR TITLE
Mention that IVPN accepts prepaid cards

### DIFF
--- a/docs/vpn.md
+++ b/docs/vpn.md
@@ -159,7 +159,7 @@ As of February 2020 [IVPN applications are now open source](https://ivpn.net/blo
 
 #### :material-check:{ .pg-green } Accepts Cash and Monero
 
-In addition to accepting credit/debit cards and PayPal, IVPN accepts Bitcoin, **Monero** and **cash/local currency** (on annual plans) as anonymous forms of payment.
+In addition to accepting credit/debit cards and PayPal, IVPN accepts Bitcoin, **Monero** and **cash/local currency** (on annual plans) as anonymous forms of payment. Prepaid cards with redeem codes are [also available](https://ivpn.net/knowledgebase/billing/voucher-cards-faq).
 
 #### :material-check:{ .pg-green } WireGuard Support
 
@@ -242,7 +242,7 @@ Mullvad provides the source code for their desktop and mobile clients in their [
 
 #### :material-check:{ .pg-green } Accepts Cash and Monero
 
-Mullvad, in addition to accepting credit/debit cards and PayPal, accepts Bitcoin, Bitcoin Cash, **Monero** and **cash/local currency** as anonymous forms of payment, prepaid cards with redeem codes are also available. They also accept Swish and bank wire transfers.
+Mullvad, in addition to accepting credit/debit cards and PayPal, accepts Bitcoin, Bitcoin Cash, **Monero** and **cash/local currency** as anonymous forms of payment. Prepaid cards with redeem codes are also available. Mullvad also accepts Swish and bank wire transfers.
 
 #### :material-check:{ .pg-green } WireGuard Support
 


### PR DESCRIPTION
Changes proposed in this PR:

- As a continuation of #2563, mention that IVPN accepts prepaid cards like Mullvad does
- As part of the previous change, embed link to IVPN's "Voucher cards FAQ" since they do not advertise this payment method on their "[Pricing](https://www.ivpn.net/pricing/)" page like [Mullvad does](https://mullvad.net/en/pricing) on theirs (under "Do you offer any type of discount?")
- Make mention of Mullvad's prepaid cards its own sentence for increased readability

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
