### PR TITLE
Update Ente GitHub links

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -127,7 +127,7 @@ Also, the Android app is not available but it is [in the works](https://discuss.
 
 - Must enforce end-to-end encryption.
 - Must offer a free plan or trial period for testing.
-- Must support TOTP or FIDO2 multi-factor authentication, or Passkey logins.
+- Must support TOTP or FIDO2 multi-factor authentication, or passkey logins.
 - Must offer a web interface which supports basic file management functionality.
 - Must allow for easy exports of all files/documents.
 - Must use standard, audited encryption.

--- a/docs/multi-factor-authentication.md
+++ b/docs/multi-factor-authentication.md
@@ -113,7 +113,8 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 
 [:octicons-home-16: Homepage](https://ente.io/auth){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://ente.io/privacy){ .card-link title="Privacy Policy" }
-[:octicons-code-16:](https://github.com/ente-io/auth){ .card-link title="Source Code" }
+[:octicons-info-16:](https://help.ente.io/auth){ .card-link title=Documentation}
+[:octicons-code-16:](https://github.com/ente-io/ente/tree/main/auth#readme){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
 <summary>Downloads</summary>

--- a/docs/photo-management.md
+++ b/docs/photo-management.md
@@ -18,7 +18,7 @@ Most cloud photo management solutions like Google Photos, Flickr, and Amazon Pho
 [:octicons-home-16: Homepage](https://ente.io){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://ente.io/privacy){ .card-link title="Privacy Policy" }
 [:octicons-info-16:](https://ente.io/faq){ .card-link title=Documentation}
-[:octicons-code-16:](https://github.com/ente-io){ .card-link title="Source Code" }
+[:octicons-code-16:](https://github.com/ente-io/ente){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
 <summary>Downloads</summary>
@@ -26,7 +26,7 @@ Most cloud photo management solutions like Google Photos, Flickr, and Amazon Pho
 - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.ente.photos)
 - [:simple-android: Android](https://ente.io/download)
 - [:simple-appstore: App Store](https://apps.apple.com/app/id1542026904)
-- [:simple-github: GitHub](https://github.com/ente-io/ente/releases)
+- [:simple-github: GitHub](https://github.com/ente-io/ente/releases?q=photos)
 - [:simple-windows11: Windows](https://ente.io/download)
 - [:simple-apple: macOS](https://ente.io/download)
 - [:simple-linux: Linux](https://ente.io/download)
@@ -56,7 +56,7 @@ Most cloud photo management solutions like Google Photos, Flickr, and Amazon Pho
 - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=org.stingle.photos)
 - [:simple-android: Android](https://f-droid.org/en/packages/org.stingle.photos)
 - [:simple-appstore: App Store](https://apps.apple.com/app/id1582535448)
-- [:simple-github: GitHub](https://github.com/stingle)
+- [:simple-github: GitHub](https://github.com/stingle/stingle-photos-android/releases)
 
 </details>
 
@@ -92,7 +92,7 @@ Most cloud photo management solutions like Google Photos, Flickr, and Amazon Pho
 
 - Cloud-hosted providers must enforce end-to-end encryption.
 - Must offer a free plan or trial period for testing.
-- Must support TOTP or FIDO2 multi-factor authentication, or Passkey logins.
+- Must support TOTP or FIDO2 multi-factor authentication, or passkey logins.
 - Must offer a web interface which supports basic file management functionality.
 - Must allow for easy exports of all files/documents.
 - Must use standard, audited encryption.

--- a/docs/productivity.md
+++ b/docs/productivity.md
@@ -82,7 +82,7 @@ In general, we define collaboration platforms as full-fledged suites which could
 Our best-case criteria represents what we would like to see from the perfect project in this category. Our recommendations may not include any or all of this functionality, but those which do may rank higher than others on this page.
 
 - Should store files in a conventional filesystem.
-- Should support TOTP or FIDO2 multi-factor authentication support, or Passkey logins.
+- Should support TOTP or FIDO2 multi-factor authentication support, or passkey logins.
 
 ## Office Suites
 


### PR DESCRIPTION
Changes proposed in this PR:

- Ente
  - Update the GitHub links for all Ente recommendations to reflect the code consolidation detailed in their [blog](https://ente.io/blog/open-sourcing-our-server/)
  - Modify GitHub releases link for Ente Photos to filter the releases to just the entries for Photos (the same was done for the Ente Auth GitHub releases link in #2458)
  - Add link to Ente Auth's documentation
- For consistency, modify Stingle GitHub link in the "Downloads" toggle to point to their Android releases page
- Lowercase the word "passkey" on several pages

Closes #2593 

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
