### PR TITLE
fix: Update last criterion on MFA tools page

### DIFF
--- a/docs/basics/email-security.md
+++ b/docs/basics/email-security.md
@@ -33,7 +33,7 @@ Email providers which allow you to use standard access protocols like IMAP and S
 
 ### How Do I Protect My Private Keys?
 
-A smartcard (such as a [YubiKey](https://support.yubico.com/hc/articles/360013790259-Using-Your-YubiKey-with-OpenPGP) or [Nitrokey](../multi-factor-authentication.md#nitrokey)) works by receiving an encrypted email message from a device (phone, tablet, computer, etc.) running an email/webmail client. The message is then decrypted by the smartcard and the decrypted content is sent back to the device.
+A smartcard (such as a [YubiKey](https://support.yubico.com/hc/articles/360013790259-Using-Your-YubiKey-with-OpenPGP) or [Nitrokey](../security-keys.md#nitrokey)) works by receiving an encrypted email message from a device (phone, tablet, computer, etc.) running an email/webmail client. The message is then decrypted by the smartcard and the decrypted content is sent back to the device.
 
 It is advantageous for the decryption to occur on the smartcard to avoid possibly exposing your private key to a compromised device.
 

--- a/docs/multi-factor-authentication.md
+++ b/docs/multi-factor-authentication.md
@@ -72,5 +72,4 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 
 - Source code must be publicly available.
 - Must not require internet connectivity.
-- Must not sync to a third-party cloud sync/backup service.
-    - **Optional** E2EE sync support with OS-native tools is acceptable, e.g. encrypted sync via iCloud.
+- Cloud syncing must be optional, and (if available) sync functionality must be E2EE.

--- a/docs/os/qubes-overview.md
+++ b/docs/os/qubes-overview.md
@@ -58,7 +58,7 @@ The [qrexec framework](https://qubes-os.org/doc/qrexec) is a core part of Qubes 
 
 We [recommend](../advanced/tor-overview.md) connecting to the Tor network via a [VPN](../vpn.md) provider, and luckily Qubes makes this easy to do with a combination of ProxyVMs and Whonix.
 
-After [creating a new ProxyVM](https://github.com/Qubes-Community/Contents/blob/master/docs/configuration/vpn.md) which connects to the VPN of your choice, you can chain your Whonix qubes to that ProxyVM **before** they connect to the Tor network, by setting the NetVM of your Whonix **Gateway** (`sys-whonix`) to the newly-created ProxyVM.
+After [creating a new ProxyVM](https://forum.qubes-os.org/t/configuring-a-proxyvm-vpn-gateway/19061) which connects to the VPN of your choice, you can chain your Whonix qubes to that ProxyVM **before** they connect to the Tor network, by setting the NetVM of your Whonix **Gateway** (`sys-whonix`) to the newly-created ProxyVM.
 
 Your qubes should be configured in a manner similar to this:
 
@@ -66,7 +66,7 @@ Your qubes should be configured in a manner similar to this:
 |-----------------|------------------------------------------------------------------------------------------------------------------|-----------------|
 | sys-net         | *Your default network qube (pre-installed)*                                                                      | *n/a*           |
 | sys-firewall    | *Your default firewall qube (pre-installed)*                                                                     | sys-net         |
-| ==sys-proxyvm== | The VPN ProxyVM you [created](https://github.com/Qubes-Community/Contents/blob/master/docs/configuration/vpn.md) | sys-firewall    |
+| ==sys-proxyvm== | The VPN ProxyVM you [created](https://forum.qubes-os.org/t/configuring-a-proxyvm-vpn-gateway/19061) | sys-firewall    |
 | sys-whonix      | Your Whonix Gateway VM                                                                                           | ==sys-proxyvm== |
 | anon-whonix     | Your Whonix Workstation VM                                                                                       | sys-whonix      |
 


### PR DESCRIPTION
Changes proposed in this PR:

- Update the last criterion on the Multi-Factor Authentication page (closes #2608)
  - In a similar fashion to #2579, the current wording regarding sync would disqualify Ente Auth, which is not at all ideal, considering the recent fiasco with Raivo. Looking at #2251, it looks like this criterion is a vestige of the now-removed Raivo recommendation. I can't access the [discussions](https://github.com/privacyguides/privacyguides.org/pull/1980#issuecomment-1431294392) that led to the [creation of this criterion](https://github.com/privacyguides/privacyguides.org/pull/1980); hopefully, this update keeps the spirit of the original criterion intact.
- Update links for Qubes ProxyVM guides as some of these docs have been migrated to the Qubes [forum](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
- Update internal link for Nitrokey so that it points to the new Security Keys page

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
