### PR TITLE
docs: Add recommendation for WebP optimization

### DIFF
--- a/docs/meta/uploading-images.md
+++ b/docs/meta/uploading-images.md
@@ -2,11 +2,11 @@
 title: Uploading Images
 ---
 
-Here are a couple of general rules for contributing to Privacy Guides:
+If you make changes to this website that involve adding new images or replacing existing ones, here are a couple of general recommendations:
 
 ## Images
 
-- We **prefer** SVG images, but if those do not exist we can use PNG images
+- We **prefer** SVG images, but if those do not exist we can use PNG images. Additionally, for cover images, we prefer that they are obtained from [Unsplash](https://unsplash.com) and are in the WebP format.
 
 Company logos have canvas size of:
 
@@ -17,7 +17,7 @@ Company logos have canvas size of:
 
 ### PNG
 
-Use the [OptiPNG](https://sourceforge.net/projects/optipng) to optimize the PNG image:
+Use the [OptiPNG](https://sourceforge.net/projects/optipng) tool to optimize PNG images:
 
 ```bash
 optipng -o7 file.png
@@ -86,4 +86,12 @@ scour --set-precision=5 \
       --enable-id-stripping \
       --protect-ids-noninkscape \
       input.svg output.svg
+```
+
+### WebP
+
+Use the [cwebp](https://developers.google.com/speed/webp/docs/using) command to convert PNG or JPEG image files to WebP format:
+
+```bash
+cwebp -q 70 -m 6 input_file -o output.webp
 ```


### PR DESCRIPTION
Changes proposed in this PR:

- "Uploading Images" meta page
  - Add recommendation for WebP optimization (closes #2660)
    - The recommendation here is derived from the [second example](https://developers.google.com/speed/webp/docs/cwebp#examples) provided by the `cwebp` documentation, with the addition of the [`-m int`](https://developers.google.com/speed/webp/docs/cwebp#options) option, which seems to achieve something similar to what the `-o` option for OptiPNG does. (Toggle the table below for a comparison between original JPEG sizes and WebP sizes using the images from #2661 as examples.)
  - Add Unsplash recommendation for cover images
    - The reasons for this addition were this GitHub [comment](https://github.com/privacyguides/privacyguides.org/pull/2409#issuecomment-1995075794) by Jonah and the [README](https://github.com/privacyguides/privacyguides.org/blob/main/theme/assets/img/cover/README.md) for the `theme/assets/img/cover/` folder.
  - Update the introduction to be more specific about the content on this page
  - Add sentence about using WebP for cover images (established in this [forum thread](https://discuss.privacyguides.net/t/reduce-file-image-file-size-on-website/14299/4))
  - Make minor grammar changes

Credit to SkewedZeppelin for providing the idea of using `cwebp` in this forum [post](https://discuss.privacyguides.net/t/reduce-file-image-file-size-on-website/14299/2)!

<details>
<summary>File size comparison between original Unsplash images and outputs of cwebp command</summary>

| Cover image | Source of image | Size of original JPEG image | Size of `cwebp` output |
|---|---|---|---|
| Language Tools | [Unsplash photo](https://unsplash.com/photos/choose-your-words-tiles-POMpXtcVYHo) by Brett Jordan | 1.4 MiB | 250.2 KiB |
| Office Suites | [Unsplash photo](https://unsplash.com/photos/multi-colored-pencils-on-pink-surface-vaTsR-ghLog) by Tamanna Rumee | 2.2 MiB | 286.7 KiB |
</details>

---
<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
