### PR TITLE
fix: Update internal link for Android Distros on OS Index

### DIFF
--- a/docs/os/index.md
+++ b/docs/os/index.md
@@ -4,7 +4,8 @@ title: Operating Systems
 We publish configuration guides for the major operating systems, because you can generally improve the amount of data that is collected about you on any option, especially if you use privacy tools like our [recommended web browsers](../desktop-browsers.md) in place of native tools where appropriate. However, some operating systems will be more privacy-respecting inherently, and it will be much harder to achieve an equivalent level of privacy on other choices.
 
 - [Recommended Linux Distros :material-arrow-right-drop-circle:](../desktop.md)
-- [Recommended Android Distros :material-arrow-right-drop-circle:](../android.md)
+- [Recommended Android Distros :material-arrow-right-drop-circle:](../android/distributions.md)
+
 The articles marked with a :material-star: are our more mature articles.
 
 ## Mobile Operating Systems


### PR DESCRIPTION
Changes proposed in this PR:

- Update the internal link to the Android Distributions page on the Operating Systems index page
- Add line break between "Recommended Android Distros" and "The articles marked with [...]" since, on the live site, the latter is on the same line as the former, which is not the best formatting in my opinion

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
