### PR TITLE
fix: Move Hardware Guide to Knowledge Base

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -372,6 +372,7 @@ nav:
       - !ENV [NAV_TECHNOLOGY_ESSENTIALS, "Technology Essentials"]:
           - "basics/passwords-overview.md"
           - "basics/multi-factor-authentication.md"
+          - "basics/hardware.md"
           - "basics/email-security.md"
           - "basics/vpn-overview.md"
       - !ENV [NAV_ADVANCED_TOPICS, "Advanced Topics"]:
@@ -423,7 +424,6 @@ nav:
           - "pastebins.md"
           - "real-time-communication.md"
       - !ENV [NAV_HARDWARE, "Hardware"]:
-          - "basics/hardware.md"
           - "mobile-phones.md"
           - "security-keys.md"
       - !ENV [NAV_OPERATING_SYSTEMS, "Operating Systems"]:


### PR DESCRIPTION
Changes proposed in this PR:

- Move the recently published Hardware Guide to the Knowledge Base
  - I'm not sure what happened to the commit mentioned [here](https://github.com/privacyguides/privacyguides.org/pull/2268#pullrequestreview-2190058447); regardless, the entry currently in `mkdocs.yml` is not consistent with the rest in the "Recommendations" section. In my opinion, this page being in the KB makes a lot of sense since it doesn't offer tool recommendations in the same way that other pages (like any of the recently split Android pages) do.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
