### PR TITLE
update: Add Youtube's Invidious blocks, and solution is to use apps

### DIFF
--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -74,7 +74,7 @@ ProxiTok is useful if you want to disable JavaScript in your browser, such as [T
 ## YouTube
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
-Google has started blocking requests from widely used IPs, including VPNs. This impacts Invidious public instances and to a lesser extent Piped public mirrors. Mobile and Desktop apps listed below can sucessfully bypass the blocking attempts { .annotate }, if you keep them updated.
+Google has started blocking requests from widely used IPs, including VPNs. This impacts Invidious public instances Piped public mirrors. Mobile and Desktop apps that directly connect to Google servers can more reliably bypass the blocking attempts { .annotate }, if you keep them updated.
 
 1. Last checked: 2024-07-31
 ### FreeTube

--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -74,7 +74,10 @@ ProxiTok is useful if you want to disable JavaScript in your browser, such as [T
 ## YouTube
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
-Google has started blocking requests from widely used IPs, including VPNs. This impacts Invidious public instances Piped public mirrors. Mobile and Desktop apps that directly connect to Google servers can more reliably bypass the blocking attempts { .annotate }, if you keep them updated.
+Google has started [requiring logins](https://github.com/iv-org/invidious/issues/4734#issuecomment-2156334756) for every YouTube client, including frontends. This impacts public [Invidious](https://github.com/iv-org/invidious/issues/4734) instances, [Piped](https://github.com/TeamPiped/Piped/issues/3658) instances, and apps which use these APIs. Desktop and mobile apps that directly connect to Google's servers can more reliably bypass such blocking attempts if you keep them updated.
+{ .annotate }
+
+</div>
 
 1. Last checked: 2024-07-31
 ### FreeTube

--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -74,7 +74,7 @@ ProxiTok is useful if you want to disable JavaScript in your browser, such as [T
 ## YouTube
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
-Google has started blocking requests from widely used IPs, including VPNs. This impacts public [Invidious](https://github.com/iv-org/invidious/issues/4734) instances, [Piped](https://github.com/TeamPiped/Piped/issues/3658) instances, and apps which use these APIs. Desktop and mobile apps that directly connect to Google's servers can more reliably bypass such blocking attempts if you keep them updated.
+Google has started blocking requests from widely used IPs, including VPNs. This impacts public [Invidious](https://github.com/iv-org/invidious/issues/4734) instances, [Piped](https://github.com/TeamPiped/Piped/issues/3658) instances, and apps which use these APIs. Desktop and mobile apps that directly connect to Google's servers can more reliably bypass such blocking attempts if you keep them updated.(1)
 { .annotate }
 
 1. Last checked: 2024-07-31

--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -74,7 +74,7 @@ ProxiTok is useful if you want to disable JavaScript in your browser, such as [T
 ## YouTube
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
-Google has started [requiring logins](https://github.com/iv-org/invidious/issues/4734#issuecomment-2156334756) for every YouTube client, including frontends. This impacts public [Invidious](https://github.com/iv-org/invidious/issues/4734) instances, [Piped](https://github.com/TeamPiped/Piped/issues/3658) instances, and apps which use these APIs. Desktop and mobile apps that directly connect to Google's servers can more reliably bypass such blocking attempts if you keep them updated.
+Google has started blocking requests from widely used IPs, including VPNs. This impacts public [Invidious](https://github.com/iv-org/invidious/issues/4734) instances, [Piped](https://github.com/TeamPiped/Piped/issues/3658) instances, and apps which use these APIs. Desktop and mobile apps that directly connect to Google's servers can more reliably bypass such blocking attempts if you keep them updated.
 { .annotate }
 
 1. Last checked: 2024-07-31

--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -72,7 +72,11 @@ ProxiTok is useful if you want to disable JavaScript in your browser, such as [T
 </div>
 
 ## YouTube
+<div class="admonition warning" markdown>
+<p class="admonition-title">Warning</p>
+Google has started blocking requests from widely used IPs, including VPNs. This impacts Invidious public instances and to a lesser extent Piped public mirrors. Mobile and Desktop apps listed below can sucessfully bypass the blocking attempts { .annotate }, if you keep them updated.
 
+1. Last checked: 2024-07-31
 ### FreeTube
 
 <div class="admonition recommendation" markdown>

--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -77,9 +77,9 @@ ProxiTok is useful if you want to disable JavaScript in your browser, such as [T
 Google has started [requiring logins](https://github.com/iv-org/invidious/issues/4734#issuecomment-2156334756) for every YouTube client, including frontends. This impacts public [Invidious](https://github.com/iv-org/invidious/issues/4734) instances, [Piped](https://github.com/TeamPiped/Piped/issues/3658) instances, and apps which use these APIs. Desktop and mobile apps that directly connect to Google's servers can more reliably bypass such blocking attempts if you keep them updated.
 { .annotate }
 
-</div>
-
 1. Last checked: 2024-07-31
+
+</div>
 ### FreeTube
 
 <div class="admonition recommendation" markdown>


### PR DESCRIPTION
Changes proposed in this PR:

Google has started blocking anonymous Youtube access from VPNs, or widely used IPs, such as those of Invidious and Piped instances. However, even with a VPN, you can still access Youtube through apps listed in the list. This adds a warning about this new development.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
