### PR TITLE
ci: Use strict mkdocs builds on PR previews

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -69,6 +69,7 @@ jobs:
       lang: en
       continue-on-error: false
       privileged: ${{ fromJSON(needs.metadata.outputs.privileged) }}
+      strict: true
 
   build_i18n:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build i18n') }}
@@ -84,6 +85,7 @@ jobs:
       lang: ${{ matrix.lang }}
       continue-on-error: true
       privileged: ${{ fromJSON(needs.metadata.outputs.privileged) }}
+      strict: true
 
   combine_build:
     needs: [build_english, build_i18n]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ on:
       privileged:
         type: boolean
         default: true
+      strict:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -60,6 +63,11 @@ jobs:
           {
             echo "EXTRA_FLAGS=""$EXTRA_FLAGS" --offline""
           } >> "$GITHUB_ENV"
+
+      - name: Set Metadata for Strict Mode
+        if: inputs.strict
+        run: |
+          echo "EXTRA_FLAGS=""$EXTRA_FLAGS" --cmd_flags=--strict"" >> "$GITHUB_ENV"
 
       - name: Download Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Changes proposed in this PR:

- enables [strict](https://www.mkdocs.org/user-guide/configuration/#strict) mkdocs builds for PR previews, this means PRs will fail to build entirely if there are broken internal links or other warnings, so we catch things like #2684 immediately

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
