### PR TITLE
docs: Use style commit type for minor grammar/typo fixes

### DIFF
--- a/docs/meta/commit-messages.md
+++ b/docs/meta/commit-messages.md
@@ -24,14 +24,6 @@ Foobar was removed due to it having numerious security issues and being unmainta
 
 You can actually add a `!` to *any* of the types on this page to denote particularly large changes, but this is generally where it will be most appropriate.
 
-## Commit message with correction
-
-We use `fix` for simple things like spelling mistakes or site related bugs. These things will usually have the `correction` or `bug` label on GitHub.
-
-```text
-fix: Correct spelling on XYZ page (#0000)
-```
-
 ## Feature/enhancement
 
 For new features or enhancements to the site, e.g. things that have the `enhancements` label on GitHub, it may be appropriate to signify these with:
@@ -42,9 +34,23 @@ feat: Add blah blah (#0000)
 This change adds the forum topics to the main page
 ```
 
+## Minor changes
+
+Small changes that **don't affect the meaning** of the article, e.g. correcting a typo, fixing grammar, changing formatting/whitespace, CSS updates, etc.
+
+```text
+style: Typo correction in VPN overview
+```
+
 ## Development-related types
 
 These commit types are typically used for changes that won't be visible to the general audience.
+
+We use `fix:` for changes that fix site related bugs. These things will usually have the `bug` label on GitHub.
+
+```text
+fix: Remove broken Invidious embeds (#0000)
+```
 
 We use `docs:` to denote changes to the developer documentation for this website, including (but not limited to) for example the README file, or most pages in `/docs/about` or `/docs/meta`:
 
@@ -64,7 +70,7 @@ We use `ci:` for commits related to GitHub Actions, DevContainers, or other auto
 ci: Update Netlify config (#0000)
 ```
 
-We use `refactor:` for changes which neither fix a bug nor add a feature.
+We use `refactor:` for changes which neither fix a bug nor add a feature, e.g. rearranging files, navigation order, etc.
 
 ```text
 refactor: Move docs/assets to theme/assets


### PR DESCRIPTION
Changes proposed in this PR:

- Use `style:` in commit messages to denote formatting/grammar/typo-correction changes to the site

Previously we've been marking these either as `fix:` (e.g. https://github.com/privacyguides/privacyguides.org/pull/2681) or `refactor:` (e.g. https://github.com/privacyguides/privacyguides.org/pull/2662). This should eliminate that ambiguity.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
