### PR TITLE
update: Add Canary Mail iOS download link

### DIFF
--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -99,8 +99,9 @@ Apple Mail has the ability to load remote content in the background or block it 
 <summary>Downloads</summary>
 
 - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.canarymail.android)
-- [:simple-appstore: App Store](https://apps.apple.com/app/id1236045954)
+- [:simple-appstore: App Store](https://apps.apple.com/app/id1155470386)
 - [:fontawesome-brands-windows: Windows](https://canarymail.io/downloads.html)
+- [:simple-apple: macOS](https://apps.apple.com/app/id1236045954)
 
 </details>
 


### PR DESCRIPTION
Changes proposed in this PR:

- Add iOS download link for Canary Mail, as suggested in https://discuss.privacyguides.net/t/canary-mail-app-store-link-is-only-for-macos/19727

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
