### PR TITLE
docs: Hide PrivacyTools FAQ from navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -452,7 +452,6 @@ nav:
           - !ENV [NAV_ONLINE_SERVICES, "Online Services"]: "about/services.md"
           - !ENV [NAV_CODE_OF_CONDUCT, "Code of Conduct"]: "CODE_OF_CONDUCT.md"
           - "about/statistics.md"
-          - "about/privacytools.md"
       - !ENV [NAV_CONTRIBUTING, "Contributing"]:
           - !ENV [NAV_WRITING_GUIDE, "Writing Guide"]:
               - "meta/writing-style.md"
@@ -471,3 +470,5 @@ nav:
 validation:
   nav:
     not_found: info
+    omitted_files: ignore
+    absolute_links: ignore


### PR DESCRIPTION
Changes proposed in this PR:

- Removes https://www.privacyguides.org/en/about/privacytools/ from navigation, i.e. it will only be accessible by direct link
  - This page is no longer relevant to any current conversations, and just discusses an old/defunct website. It may be useful to reference directly in the future, but nobody is seeking it out anymore.
  - I also just want to reduce the amount of "meta-commentary" we do in general (see also: https://github.com/privacyguides/privacyguides.org/pull/2728#discussion_r1728352403) and let the work speak for itself.

<!-- SCROLL TO BOTTOM TO AGREE!:
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, please
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
Any external relationship can trigger a conflict of interest.
-->

<summary>

<!-- To agree, place an x in the box below, like: [x] -->
- [x] I agree to the terms listed below:
  <details><summary>Contribution terms (click to expand)</summary>
  1) I am the sole author of this work.
  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
  3) I have disclosed any relevant conflicts of interest in my post.
  4) I agree to the Community Code of Conduct.
  </details>

<!-- What's this? When you submit a PR, you keep the Copyright for the work you
are contributing. We need you to agree to the above terms in order for us to
publish this contribution to our website. -->
