### PR TITLE
docs: Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,14 @@
-Changes proposed in this PR:
+List of changes proposed in this PR:
 
 -
 
-<!-- SCROLL TO BOTTOM TO AGREE!:
+<!--
 Please use a descriptive title for your PR, it will be included in our changelog!
 
-If you are making changes that you have a conflict of interest with, please
+If you are making changes that you have a conflict of interest with, you MUST
 disclose this as well (this does not disqualify your PR by any means):
 
 Conflict of interest contributions involve contributing about yourself,
 family, friends, clients, employers, or your financial and other relationships.
-Any external relationship can trigger a conflict of interest.
+ANY external relationship can trigger a conflict of interest.
 -->
-
-<summary>
-
-<!-- To agree, place an x in the box below, like: [x] -->
-- [ ] I agree to the terms listed below:
-  <details><summary>Contribution terms (click to expand)</summary>
-  1) I am the sole author of this work.
-  2) I agree to grant Privacy Guides a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform, relicense, and distribute my contribution as part of this project.
-  3) I have disclosed any relevant conflicts of interest in my post.
-  4) I agree to the Community Code of Conduct.
-  </details>
-
-<!-- What's this? When you submit a PR, you keep the Copyright for the work you
-are contributing. We need you to agree to the above terms in order for us to
-publish this contribution to our website. -->


### PR DESCRIPTION
Changes proposed in this PR:

- Remove "contribution terms" from PR description template.

This was really only necessary if we ever desired to relicense the site in the future. I was concerned about this back when the site was licensed CC BY-ND. However, I think we should just commit fully to our current license, and eliminate any temptation to keep messing with licenses, we've switched things around enough as-is.

I will note that this would also remove the potential for us to switch to a less restrictive license, like CC BY or even back to CC0 again. It's my understanding that nobody here desires to do so though.