### PR TITLE
update: Note that blocking cookies on Thunderbird may affect email logins

### DIFF
--- a/docs/email-clients.md
+++ b/docs/email-clients.md
@@ -51,6 +51,8 @@ OpenPGP also does not support [forward secrecy](https://en.wikipedia.org/wiki/Fo
 
 #### Recommended Configuration
 
+<div class="annotate" markdown>
+
 We recommend changing some of these settings to make Thunderbird a little more private.
 
 These options can be found in :material-menu: → **Settings** → **Privacy & Security**.
@@ -58,7 +60,11 @@ These options can be found in :material-menu: → **Settings** → **Privacy & S
 ##### Web Content
 
 - [ ] Uncheck  **Remember websites and links I've visited**
-- [ ] Uncheck  **Accept cookies from sites**
+- [ ] Uncheck  **Accept cookies from sites** (1)
+
+</div>
+
+1. You may need to keep this setting checked when you're logging in to some providers such as Gmail, or via an institution’s SSO. You should uncheck it once you log in successfully.
 
 ##### Telemetry
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Add condition for blocking cookies on Thunderbird, as it may prevent people from logging in to Gmail if it's enabled beforehand
  - Relevant discussion: https://discuss.privacyguides.net/t/set-accept-cookies-from-sites-and-set-accept-third-party-cookies-to-never-in-mozilla-thunderbird/20411/10
  - As well as Microsoft365 via SSO according to this reply: https://discuss.privacyguides.net/t/set-accept-cookies-from-sites-and-set-accept-third-party-cookies-to-never-in-mozilla-thunderbird/20411/17

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
