### PR TITLE
fix: Remove Piped Being Able to Play Age Restricted Videos

### DIFF
--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -270,7 +270,7 @@ Piped requires JavaScript in order to function and there are a number of public 
 <div class="admonition tip" markdown>
 <p class="admonition-title">Tip</p>
 
-Piped is useful if you want to use [SponsorBlock](https://sponsor.ajay.app) without installing an extension or to access age-restricted content without an account. It does not provide privacy by itself, and we don’t recommend logging into any accounts.
+Piped is useful if you want to use [SponsorBlock](https://sponsor.ajay.app) without installing an extension. It does not provide privacy by itself, and we don’t recommend logging into any accounts.
 
 </div>
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Piped can no longer play age restricted YouTube videos it seems so I removed the part

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
