### PR TITLE
docs: Transfer security criteria from developer reqs to specific criteria

### DIFF
--- a/docs/about/criteria.md
+++ b/docs/about/criteria.md
@@ -21,9 +21,6 @@ We have these requirements in regard to developers which wish to submit their pr
 
 - Must disclose affiliation, i.e. your position within the project being submitted.
 
-- Must have a security whitepaper if it is a project that involves handling of sensitive information like a messenger, password manager, encrypted cloud storage, etc.
-    - Third party audit status. We want to know if you have one, or have one planned. If possible please mention who will be conducting the audit.
-
 - Must explain what the project brings to the table in regard to privacy.
     - Does it solve any new problem?
     - Why should anyone use it over the alternatives?

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -2,7 +2,7 @@
 meta_title: "The Best Private and Secure Cloud Storage Providers - Privacy Guides"
 title: "Cloud Storage"
 icon: material/file-cloud
-description: Many cloud storage providers require your trust that they will not look at your files. These are private alternatives!
+description: Many cloud storage providers require your trust that they will not look at your files. These are private alternatives.
 cover: cloud.webp
 ---
 <small>Protects against the following threat(s):</small>
@@ -129,6 +129,7 @@ An Android app is not available but it is [in the works](https://discuss.privacy
 ### Minimum Requirements
 
 - Must enforce end-to-end encryption.
+- Must have thoroughly documented encryption and security practices.
 - Must offer a free plan or trial period for testing.
 - Must support TOTP or FIDO2 multi-factor authentication, or passkey logins.
 - Must offer a web interface which supports basic file management functionality.
@@ -139,8 +140,8 @@ An Android app is not available but it is [in the works](https://discuss.privacy
 Our best-case criteria represents what we would like to see from the perfect project in this category. Our recommendations may not include any or all of this functionality, but those which do may rank higher than others on this page.
 
 - Clients should be open source.
-- Clients should be audited in their entirety by an independent third-party.
+- Clients should be audited in their entirety by an independent third party.
 - Should offer native clients for Linux, Android, Windows, macOS, and iOS.
     - These clients should integrate with native OS tools for cloud storage providers, such as Files app integration on iOS, or DocumentsProvider functionality on Android.
-- Should support easy file-sharing with other users.
+- Should support easy file sharing with other users.
 - Should offer at least basic file preview and editing functionality on the web interface.

--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -259,11 +259,11 @@ Session has a [whitepaper](https://arxiv.org/pdf/2002.04609.pdf) describing the 
 
 ### Minimum Requirements
 
-- Has open-source clients.
-- Does not require sharing personal identifiers (phone numbers or emails in particular) with contacts.
-- Uses E2EE for private messages by default.
-- Supports E2EE for all messages.
-- Has been independently audited.
+- Must have open-source clients.
+- Must not require sharing personal identifiers (phone numbers or emails in particular) with contacts.
+- Must use E2EE for private messages by default.
+- Must support E2EE for all messages.
+- Must have a security whitepaper as well as a published audit from a reputable, independent third party.
 
 ### Best-Case
 

--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -270,12 +270,12 @@ Session has a [whitepaper](https://arxiv.org/pdf/2002.04609.pdf) describing the 
 
 Our best-case criteria represents what we would like to see from the perfect project in this category. Our recommendations may not include any or all of this functionality, but those which do may rank higher than others on this page.
 
-- Supports forward secrecy[^1]
-- Supports Future Secrecy (Post-Compromise Security)[^2]
-- Has open-source servers.
-- Decentralized, i.e. [federated or P2P](advanced/communication-network-types.md).
-- Uses E2EE for all messages by default.
-- Supports Linux, macOS, Windows, Android, and iOS.
+- Should support forward secrecy[^1]
+- Should support Future Secrecy (Post-Compromise Security)[^2]
+- Should have open-source servers.
+- Should be decentralized, i.e. [federated or P2P](advanced/communication-network-types.md).
+- Should use E2EE for all messages by default.
+- Should support Linux, macOS, Windows, Android, and iOS.
 
 [^1]: [Forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy) is where keys are rotated very frequently, so that if the current encryption key is compromised, it does not expose **past** messages as well.
 [^2]: Future Secrecy (or Post-Compromise Security) is a feature where an attacker is prevented from decrypting **future** messages after compromising a private key, unless they compromise more session keys in the future as well. This effectively forces the attacker to intercept all communication between parties, since they lose access as soon as a key exchange occurs that is not intercepted.

--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -273,7 +273,7 @@ Our best-case criteria represents what we would like to see from the perfect pro
 - Should support forward secrecy[^1]
 - Should support Future Secrecy (Post-Compromise Security)[^2]
 - Should have open-source servers.
-- Should be decentralized, i.e. [federated or P2P](advanced/communication-network-types.md).
+- Should be decentralized, i.e. [federated](advanced/communication-network-types.md#federated-networks) or [P2P](advanced/communication-network-types.md#peer-to-peer-networks).
 - Should use E2EE for all messages by default.
 - Should support Linux, macOS, Windows, Android, and iOS.
 

--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -263,7 +263,8 @@ Session has a [whitepaper](https://arxiv.org/pdf/2002.04609.pdf) describing the 
 - Must not require sharing personal identifiers (phone numbers or emails in particular) with contacts.
 - Must use E2EE for private messages by default.
 - Must support E2EE for all messages.
-- Must have a security whitepaper as well as a published audit from a reputable, independent third party.
+- Must have thoroughly documented encryption and security practices.
+- Must have a published audit from a reputable, independent third party.
 
 ### Best-Case
 


### PR DESCRIPTION
List of changes proposed in this PR:

This PR sprang from the discussion in https://github.com/privacyguides/privacyguides.org/pull/2727#issuecomment-2306972391 and some discussion in the team chat.

- General Criteria meta page
  - Remove the security whitepaper requirement from the developer self-submission requirements
    - Reason: In the current wording, this req only applies to certain categories of tools: "a project that involves handling of sensitive information like a messenger, password manager, encrypted cloud storage, etc." As such, I don't think it makes much sense to mention the req here. Rather, I think it is better to lay out this requirement in the specific criteria of tool categories where it applies (e.g., the criteria for cloud-based password managers).
  - Remove the line about third-party audit status
    - Reason: Like the whitepaper req, this only applies to certain categories of tools, so it's somewhat misplaced on this page. The developer will have to meet the specific criteria for the category that their tool falls under, anyway.
    - Moreover, requesting a developer for information about whether they have an audit lined up doesn't make much sense to me. The *promise* of a *future* audit shouldn't be taken into account when they are evaluated for inclusion on the site. **Either they have one at the time of evaluation, or they don't.** A developer putting it out to the world that they have requested a third-party audit is tantamount to not having one at the time of evaluation. In such a case, the tool suggestion thread would be marked as #rejected if the category-specific criteria demands an audit, I think.
- Cloud Storage page
  - Add security whitepaper minimum req to criteria to cover the first change in the previous section
- Messengers page
  - Add security whitepaper minimum req to criteria to cover the first change in the General Criteria section
  - Apply specific [guidance about the language for requirements](https://www.privacyguides.org/en/meta/writing-style/#use-must-for-requirements) from the Writing Style page to the criteria
- Make some minor grammar changes

The cloud-based password managers criteria already has a security whitepaper requirement.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
