### PR TITLE
update: Include more details about FOSS Molly distributions

### DIFF
--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -98,7 +98,11 @@ Molly is updated every two weeks to include the latest features and bug fixes fr
 
 Note that you are trusting multiple parties by using Molly, as you now need to trust the Signal team *and* the Molly team to deliver safe and timely updates.
 
-There is a version of Molly called **Molly-FOSS** which removes proprietary code like the Google services used by both Signal and Molly, at the expense of some features like push notifications. There is also a version called [**Molly-UP**](https://github.com/mollyim/mollyim-android#unifiedpush) which is based on Molly-FOSS and adds back support for push notifications with UnifiedPush, but it requires self-hosting a program on a separate computer to function. All three versions of Molly provide the same security improvements.
+There is a version of Molly called **Molly-FOSS** which removes proprietary code like the Google services used by both Signal and Molly, at the expense of some features like battery-saving push notifications via Google Play Services. 
+
+There is also a version called [**Molly-UP**](https://github.com/mollyim/mollyim-android#unifiedpush) which is based on Molly-FOSS and adds support for push notifications with [UnifiedPush](https://unifiedpush.org/), an open source alternative to the push notifications provided by Google Play Services, but it requires running a separate program called [Mollysocket](https://github.com/mollyim/mollysocket) to function. Mollysocket can either be self-hosted on a separate computer or server (VPS), or alternatively a public Mollysocket instance can be used ([step-by-step tutorial, in German](https://www.kuketz-blog.de/messenger-wechsel-von-signal-zu-molly-unifiedpush-mollysocket-ntfy/)). 
+
+All three versions of Molly provide the same security improvements.
 
 Molly and Molly-FOSS support [reproducible builds](https://github.com/mollyim/mollyim-android/tree/main/reproducible-builds), meaning it's possible to confirm that the compiled APKs match the source code.
 


### PR DESCRIPTION
List of changes proposed in this PR:

- The current description of Molly-FOSS is incorrect. Molly-FOSS still has working push notifications, just using Websockets rather than Google Play. 
- Added some more detail on Molly-UP. There's also the option of using a public Mollysocket instance, so you don't _have_ to self-host. However the only one I'm aware of is Adminforge.de. I added a link to a step-by-step tutorial, which is in German but it's the only easy-to-follow tutorial I know for a migration from Signal to Molly-UP. Feel free to remove it again if you only want English-language links.