### PR TITLE
update: Description of group calls for Element

### DIFF
--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -212,7 +212,7 @@ Messages and files shared in private rooms (those which require an invite) are b
 
 Profile pictures, reactions, and nicknames are not encrypted.
 
-Group voice and video calls are [not](https://github.com/vector-im/element-web/issues/12878) E2EE and use Jitsi, but this is expected to change with [Native Group VoIP Signalling](https://github.com/matrix-org/matrix-doc/pull/3401). Group calls have [no authentication](https://github.com/vector-im/element-web/issues/13074) currently, meaning that non-room participants can also join the calls. We recommend that you do not use this feature for private meetings.
+With the integration of [Element Call](https://element.io/blog/we-have-lift-off-element-x-call-and-server-suite-are-ready) into Element's web app, desktop apps, and its [rewritten mobile apps](https://element.io/blog/element-x-experience-the-future-of-element), group VoIP and video calls are E2EE by default.
 
 The Matrix protocol itself [theoretically supports forward secrecy](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/megolm.md#partial-forward-secrecy)[^1], however this is [not currently supported in Element](https://github.com/vector-im/element-web/issues/7101) due to it breaking some aspects of the user experience such as key backups and shared message history.
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Under the Element listing, update the description of how Element handles group calls and its implication on E2EE
  - Relevant discussion: https://discuss.privacyguides.net/t/we-have-lift-off-element-x-call-and-server-suite-are-ready/21093
  - Note that the changes in this PR are conservative. I entertained the possibility of replacing the current GitHub download link with the one for Element X since it benefits from the integration with Element Call (unlike the legacy app), but some members of the community (such as those in the above thread) reported issues with the app.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
