### PR TITLE
update: Remove AMO link from uBOL card

### DIFF
--- a/docs/browser-extensions.md
+++ b/docs/browser-extensions.md
@@ -69,7 +69,6 @@ uBlock Origin also has a "Lite" version of their extension, which offers a very 
 <details class="downloads" markdown>
 <summary>Downloads</summary>
 
-- [:simple-firefoxbrowser: Firefox](https://addons.mozilla.org/addon/ublock-origin-lite)
 - [:simple-googlechrome: Chrome](https://chrome.google.com/webstore/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh)
 
 </details>


### PR DESCRIPTION
List of changes proposed in this PR:

- Remove the AMO download link from the uBlock Origin Lite card
  - Relevant discussion: https://discuss.privacyguides.net/t/ublock-origin-lite-maker-ends-firefox-store-support/21204
    - The above thread links to a third-party article, so here's a direct link to the relevant GitHub issue: https://github.com/uBlockOrigin/uBOL-home/issues/197#issuecomment-2377395301

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
