### PR TITLE
update: Remove Play Store link for Syncthing

### DIFF
--- a/docs/file-sharing.md
+++ b/docs/file-sharing.md
@@ -142,7 +142,6 @@ We don't recommend using the [E2EE App](https://apps.nextcloud.com/apps/end_to_e
 <details class="downloads" markdown>
 <summary>Downloads</summary>
 
-- [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid)
 - [:fontawesome-brands-windows: Windows](https://syncthing.net/downloads)
 - [:simple-apple: macOS](https://syncthing.net/downloads)
 - [:simple-linux: Linux](https://syncthing.net/downloads)


### PR DESCRIPTION
List of changes proposed in this PR:

- Remove defunct Google Play Store link in the Downloads section of the Syncthing card
  - Relevant discussion: https://discuss.privacyguides.net/t/syncthing-for-android-discontinued/21644/9

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
