### PR TITLE
docs: Replace OpenCollective with Github Sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
     <img src="https://img.shields.io/github/commits-since/privacyguides/privacyguides.org/latest"></a>
   <a href="https://crowdin.com/project/privacyguides">
     <img src="https://badges.crowdin.net/privacyguides/localized.svg"></a>
-  <a href="https://opencollective.com/privacyguides">
-    <img src="https://img.shields.io/opencollective/all/privacyguides"></a>
+  <a href="https://github.com/sponsors/privacyguides#sponsors">
+    <img src="https://img.shields.io/github/sponsors/privacyguides"></a>
   <a href="https://squidfunk.github.io/mkdocs-material/">
     <img src="https://img.shields.io/badge/Material_for_MkDocs-526CFE?logo=MaterialForMkDocs&logoColor=white"></a>
   <a href="https://github.com/privacyguides/privacyguides.org/actions/workflows/publish-release.yml">


### PR DESCRIPTION
List of changes proposed in this PR:

- replaced open collective badge with github sponsors on the README

closes #2743 
<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
