### PR TITLE
style: typo in 'Create Internet Accounts Privately' guide

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -118,7 +118,7 @@ In 2022, we completed the transition of our main website framework from Jekyll t
 
 We additionally launched our new discussion forum at [discuss.privacyguides.net](https://discuss.privacyguides.net) as a community platform to share ideas and ask questions about our mission. This augments our existing community on Matrix, and replaced our previous GitHub Discussions platform, decreasing our reliance on proprietary discussion platforms.
 
-In 2023, we launched international translations of our website in [French](https://www.privacyguides.org/fr/), [Hebrew](https://www.privacyguides.org/he/), [Dutch](https://www.privacyguides.org/nl/), and more languages, made possible by our excellent translation team on [Crowdin](https://crowdin.com/project/privacyguides). We plan to continue carrying forward our mission of outreach and education, and finding ways to more clearly highlight the dangers of a lack of privacy awareness in the modern digital age, and the prevalence and harms of security breaches across the technology industry.
+In 2023, we launched international translations of our website in [French](https://www.privacyguides.org/fr), [Hebrew](https://www.privacyguides.org/he), [Dutch](https://www.privacyguides.org/nl), and more languages, made possible by our excellent translation team on [Crowdin](https://crowdin.com/project/privacyguides). We plan to continue carrying forward our mission of outreach and education, and finding ways to more clearly highlight the dangers of a lack of privacy awareness in the modern digital age, and the prevalence and harms of security breaches across the technology industry.
 
 ## Site License
 

--- a/docs/about/contributors.md
+++ b/docs/about/contributors.md
@@ -10,7 +10,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 | Emoji | Type | Description
 | --- | --- | ---
-| 📖 | `doc` | A contributor to the content on [privacyguides.org](https://www.privacyguides.org/en/).
+| 📖 | `doc` | A contributor to the content on [privacyguides.org](https://www.privacyguides.org/en).
 | 👀 | `review` | Someone who has taken the time to review [pull requests](https://github.com/privacyguides/privacyguides.org/pulls) to the site.
 | 📝 | `blog` | Someone who has written a [blog](https://blog.privacyguides.org) post for us.
 | 💬 | `question` | Someone who has been helpful when answering questions on our [forum](https://discuss.privacyguides.net) or Matrix channels.

--- a/docs/about/jobs/journalist.md
+++ b/docs/about/jobs/journalist.md
@@ -20,7 +20,7 @@ Privacy Guides is a small, largely volunteer-driven nonprofit media organization
 Your responsibilities will include, but aren’t limited to:
 
 - Creating high-quality articles for our [knowledge base](../../basics/why-privacy-matters.md).
-- Performing product reviews for our [reviews](https://www.privacyguides.org/articles/category/reviews/) section and [tool recommendations](../../tools.md).
+- Performing product reviews for our [reviews](https://www.privacyguides.org/articles/category/reviews) section and [tool recommendations](../../tools.md).
 - Researching new topics to cover.
 - Interviewing and fact-checking all relevant sources.
 - Regular posting of high-quality, unbiased journalistic content across our platforms.

--- a/docs/basics/account-creation.md
+++ b/docs/basics/account-creation.md
@@ -74,7 +74,7 @@ Malicious applications, particularly on mobile devices where the application has
 
 ### Phone number
 
-We recommend avoiding services that require a phone number for sign up. A phone number can identity you across multiple services and depending on data sharing agreements this will make your usage easier to track, particularly if one of those services is breached as the phone number is often **not** encrypted.
+We recommend avoiding services that require a phone number for sign up. A phone number can identify you across multiple services and depending on data sharing agreements this will make your usage easier to track, particularly if one of those services is breached as the phone number is often **not** encrypted.
 
 You should avoid giving out your real phone number if you can. Some services will allow the use of VOIP numbers, however these often trigger fraud detection systems, causing an account to be locked down, so we don't recommend that for important accounts.
 

--- a/docs/data-broker-removals.md
+++ b/docs/data-broker-removals.md
@@ -27,21 +27,21 @@ The quickest, most effective, and most private way to remove yourself from peopl
 
 You should search for your information on these sites first, and submit an opt-out request if your information is found. Removing your data from these providers typically removes your data from many smaller sites at the same time.
 
-- Advanced Background Checks ([Search](https://www.advancedbackgroundchecks.com/), [Opt-Out](https://www.advancedbackgroundchecks.com/removal))
-- BeenVerified ([Search](https://www.beenverified.com/app/optout/search), [Opt-Out](https://www.beenverified.com/app/optout/address-search))
+- Advanced Background Checks ([Search](https://advancedbackgroundchecks.com), [Opt-Out](https://advancedbackgroundchecks.com/removal))
+- BeenVerified ([Search](https://beenverified.com/app/optout/search), [Opt-Out](https://beenverified.com/app/optout/address-search))
 - CheckPeople ([Search](https://checkpeople.com/do-not-sell-info), select *Remove Record* to opt-out)
-- ClustrMaps ([Search](https://clustrmaps.com/), [Opt-Out](https://clustrmaps.com/bl/opt-out))
-- Dataveria ([Search](https://dataveria.com/), [Opt-Out](https://dataveria.com/ng/control/privacy))
-- Glad I Know ([Search](https://gladiknow.com/), [Opt-Out](https://gladiknow.com/opt-out))
-- InfoTracer ([Search](https://www.infotracer.com/), [Opt-Out](https://www.infotracer.com/optout))
-- Intelius ([Search](https://www.intelius.com/), [Opt-Out](https://suppression.peopleconnect.us/login))
-- PeekYou ([Search](https://www.peekyou.com/), [Opt-Out](https://www.peekyou.com/about/contact/optout))
-- PublicDataUSA ([Search](https://www.publicdatausa.com/), [Opt-Out](https://www.publicdatausa.com/remove.php))
-- Radaris ([Search](https://radaris.com/), [Opt-Out](https://radaris.com/page/how-to-remove))
-- Spokeo ([Search](https://www.spokeo.com/search), [Opt-Out](https://www.spokeo.com/optout))
-- That's Them ([Search](https://thatsthem.com/), [Opt-Out](https://thatsthem.com/optout))
-- USPhonebook ([Search and Opt-Out](https://www.usphonebook.com/opt-out/))
-- Whitepages ([Search](https://www.whitepages.com/), [Opt-Out](https://www.whitepages.com/suppression_requests))
+- ClustrMaps ([Search](https://clustrmaps.com), [Opt-Out](https://clustrmaps.com/bl/opt-out))
+- Dataveria ([Search](https://dataveria.com), [Opt-Out](https://dataveria.com/ng/control/privacy))
+- Glad I Know ([Search](https://gladiknow.com), [Opt-Out](https://gladiknow.com/opt-out))
+- InfoTracer ([Search](https://infotracer.com), [Opt-Out](https://infotracer.com/optout))
+- Intelius ([Search](https://intelius.com), [Opt-Out](https://suppression.peopleconnect.us/login))
+- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/optout))
+- PublicDataUSA ([Search](https://publicdatausa.com), [Opt-Out](https://publicdatausa.com/remove.php))
+- Radaris ([Search](https://radaris.com), [Opt-Out](https://radaris.com/page/how-to-remove))
+- Spokeo ([Search](https://spokeo.com/search), [Opt-Out](https://spokeo.com/optout))
+- That's Them ([Search](https://thatsthem.com), [Opt-Out](https://thatsthem.com/optout))
+- USPhonebook ([Search and Opt-Out](https://usphonebook.com/opt-out))
+- Whitepages ([Search](https://whitepages.com), [Opt-Out](https://whitepages.com/suppression_requests))
 
 <div class="admonition tip" markdown>
 <p class="admonition-title">A tip on opt-out strategy</p>
@@ -84,9 +84,9 @@ Our testing indicates that EasyOptOuts provides the best value out of any data r
 
 EasyOptOuts does not cover the following sites we consider to be "high priority," so you should still manually opt-out of:
 
-- Intelius ([Search](https://www.intelius.com/), [Opt-Out](https://suppression.peopleconnect.us/login))
-- PeekYou ([Search](https://www.peekyou.com/), [Opt-Out](https://www.peekyou.com/about/contact/optout))
-- PublicDataUSA ([Search](https://www.publicdatausa.com/), [Opt-Out](https://www.publicdatausa.com/remove.php))
+- Intelius ([Search](https://intelius.com), [Opt-Out](https://suppression.peopleconnect.us/login))
+- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/optout))
+- PublicDataUSA ([Search](https://publicdatausa.com), [Opt-Out](https://publicdatausa.com/remove.php))
 
 </div>
 

--- a/docs/real-time-communication.md
+++ b/docs/real-time-communication.md
@@ -100,7 +100,7 @@ Note that you are trusting multiple parties by using Molly, as you now need to t
 
 There is a version of Molly called **Molly-FOSS** which removes proprietary code like the Google services used by both Signal and Molly, at the expense of some features like battery-saving push notifications via Google Play Services.
 
-There is also a version called [**Molly-UP**](https://github.com/mollyim/mollyim-android#unifiedpush) which is based on Molly-FOSS and adds support for push notifications with [UnifiedPush](https://unifiedpush.org/), an open source alternative to the push notifications provided by Google Play Services, but it requires running a separate program called [Mollysocket](https://github.com/mollyim/mollysocket) to function. Mollysocket can either be self-hosted on a separate computer or server (VPS), or alternatively a public Mollysocket instance can be used ([step-by-step tutorial, in German](https://kuketz-blog.de/messenger-wechsel-von-signal-zu-molly-unifiedpush-mollysocket-ntfy)).
+There is also a version called [**Molly-UP**](https://github.com/mollyim/mollyim-android#unifiedpush) which is based on Molly-FOSS and adds support for push notifications with [UnifiedPush](https://unifiedpush.org), an open source alternative to the push notifications provided by Google Play Services, but it requires running a separate program called [Mollysocket](https://github.com/mollyim/mollysocket) to function. Mollysocket can either be self-hosted on a separate computer or server (VPS), or alternatively a public Mollysocket instance can be used ([step-by-step tutorial, in German](https://kuketz-blog.de/messenger-wechsel-von-signal-zu-molly-unifiedpush-mollysocket-ntfy)).
 
 All three versions of Molly provide the same security improvements.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -88,7 +88,7 @@ For more details about each project, why they were chosen, and additional tips o
 
     ---
 
-    We recommend **Safari** due to its [anti-fingerprinting](https://webkit.org/blog/15697/private-browsing-2-0/) features and default tracker blocking. It also separates your cookies in private browsing mode to prevent tracking between tabs.
+    We recommend **Safari** due to its [anti-fingerprinting](https://webkit.org/blog/15697/private-browsing-2-0) features and default tracker blocking. It also separates your cookies in private browsing mode to prevent tracking between tabs.
 
     - [Read Full Review :material-arrow-right-drop-circle:](mobile-browsers.md#safari-ios)
 

--- a/docs/tor.md
+++ b/docs/tor.md
@@ -127,7 +127,7 @@ All versions are signed using the same signature so they should be compatible wi
 
 ![Onion Browser logo](assets/img/self-contained-networks/onion_browser.svg){ align=right }
 
-**Onion Browser** is an open-source browser that lets you browse the web anonymously over the Tor network on iOS devices and is endorsed by the [Tor Project](https://support.torproject.org/glossary/onion-browser). [:material-star-box: Read our latest Onion Browser review.](/articles/2024/09/18/onion-browser-review/)
+**Onion Browser** is an open-source browser that lets you browse the web anonymously over the Tor network on iOS devices and is endorsed by the [Tor Project](https://support.torproject.org/glossary/onion-browser). [:material-star-box: Read our latest Onion Browser review.](/articles/2024/09/18/onion-browser-review)
 
 [:octicons-home-16: Homepage](https://onionbrowser.com){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://onionbrowser.com/privacy-policy){ .card-link title="Privacy Policy" }


### PR DESCRIPTION
List of changes proposed in this PR:

- 'identity' to 'identify' in 'Phone Number' section