### PR TITLE
update: Remove outdated master password info from Proton Pass entry

### DIFF
--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -228,8 +228,6 @@ Bitwarden's server-side code is [open source](https://github.com/bitwarden/serve
 
 With the acquisition of SimpleLogin in April 2022, Proton has offered a "hide-my-email" feature that lets you create 10 aliases (free plan) or unlimited aliases (paid plans).
 
-Proton Pass currently doesn't have any "master password" functionality, which means that your vault is protected with the password for your Proton account and any of their supported [two factor authentication](basics/multi-factor-authentication.md) methods.
-
 The Proton Pass mobile apps and browser extension underwent an audit performed by Cure53 throughout May and June of 2023. The security analysis company concluded:
 
 > Proton Pass apps and components leave a rather positive impression in terms of security.


### PR DESCRIPTION
* Removes information that states Proton Pass cannot have a password different from the rest of your Proton account.

This PR removes text from the Proton Pass entry that states a separate password cannot be set for Proton Pass. 
Proton added an "Extra password" option to Proton Pass sometime around July 2024:
https://proton.me/blog/pass-secure-link-sharing

> [...]in response to feedback from the community, we’re also launching an Extra Password feature alongside Secure Links. This optional feature lets you create a second password to access credentials stored in Pass for greater compartmentalization and peace of mind. Extra Password is available to the entire Proton Pass community, including those with Free plans.

Screenshot:
![image](https://github.com/user-attachments/assets/055a4658-5a6f-4dd8-8fb9-a947d02ad6be)

Thanks!