### PR TITLE
update: List of EasyOptOuts unsupported sites

### DIFF
--- a/docs/data-broker-removals.md
+++ b/docs/data-broker-removals.md
@@ -85,8 +85,6 @@ Our testing indicates that EasyOptOuts provides the best value out of any data r
 EasyOptOuts does not cover the following sites we consider to be "high priority," so you should still manually opt-out of:
 
 - Intelius ([Search](https://intelius.com), [Opt-Out](https://suppression.peopleconnect.us/login))
-- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/optout))
-- PublicDataUSA ([Search](https://publicdatausa.com), [Opt-Out](https://publicdatausa.com/remove.php))
 
 </div>
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Removes PeekYou and PublicDataUSA from the unsupported site list

Both of these sites are now listed on EasyOptOut's supported sites list: https://www.easyoptouts.com/sites

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
