### PR TITLE
update: Add note about Mull open in private tab option

### DIFF
--- a/docs/mobile-browsers.md
+++ b/docs/mobile-browsers.md
@@ -302,7 +302,8 @@ Mull enables many features upstreamed by the [Tor uplift project](https://wiki.m
 
 We would suggest installing [uBlock Origin](browser-extensions.md#ublock-origin) as a content blocker if you want to block trackers within Mull.
 
-Mull comes with privacy protecting settings configured by default. You might consider configuring the **Delete browsing data on quit** options in Mull's settings if you want to close all your open tabs when quitting the app automatically, or clear other data such as browsing history and cookies automatically.
+Mull comes with privacy protecting settings configured by default. When you use third-party apps and click links if you want them to open in a private window, you can enable "Open links in a private tab".
+You might consider configuring the **Delete browsing data on quit** options in Mull's settings if you want to close all your open tabs when quitting the app automatically, or clear other data such as browsing history and cookies automatically.
 
 Because Mull has more advanced and strict privacy protections enabled by default compared to most browsers, some websites may not load or work properly unless you adjust those settings. You can consult this [list of known issues and workarounds](https://divestos.org/pages/broken#mull) for advice on a potential fix if you do encounter a broken site. Adjusting a setting in order to fix a website could impact your privacy/security, so make sure you fully understand any instructions you follow.
 


### PR DESCRIPTION
Wording is bad and can be improved.

First discussed here https://discuss.privacyguides.net/t/usefull-mull-feature-is-not-recommended/23164


If Cromite has this feature too then it could be added.
List of changes proposed in this PR:

-Add info about Mull "Open links in private tabs" which when you use apps and their 'built-in' browser will open in private tabs instead of standard. 

