### PR TITLE
update: New features in Brave Browser Android and iOS

### DIFF
--- a/docs/mobile-browsers.md
+++ b/docs/mobile-browsers.md
@@ -136,6 +136,7 @@ Shields' options can be downgraded on a per-site basis as needed, but by default
     - [x] Select **Auto-Redirect Tracking URLs**
     - [x] (Optional) Select **Block Scripts** (1)
     - [x] Select **Block Fingerprinting**
+    - [x] Select **Site Tabs Closed** under *Auto Shred*
 
     <details class="warning" markdown>
     <summary>Use default filter lists</summary>
@@ -165,6 +166,7 @@ Shields' options can be downgraded on a per-site basis as needed, but by default
     - [x] Select **Disable non-proxied UDP** under [*WebRTC IP handling policy*](https://support.brave.com/hc/articles/360017989132-How-do-I-change-my-Privacy-Settings#webrtc)
     - [x] (Optional) Select **No protection** under *Safe Browsing* (1)
     - [ ] Uncheck **Allow sites to check if you have payment methods saved**
+    - [ ] Uncheck **V8 Optimizer** under *Manage V8 security*
     - [x] Select **Close tabs on exit**
     - [ ] Uncheck **Allow privacy-preserving product analytics (P3A)**
     - [ ] Uncheck **Automatically send diagnostic reports**


### PR DESCRIPTION
List of changes proposed in this PR:

- Brave (mobile)
  - Include suggestion to disable V8, which was recently added to the Android version (closes #2900)
  - Include suggestion to enable [Auto Shred](https://brave.com/privacy-updates/30-shred-button/) on the iOS version, which functions in a similar way as Forgetful Browsing on desktop and Android does.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
