### PR TITLE
update: Correct LanguageTool's data processing note

### DIFF
--- a/docs/language-tools.md
+++ b/docs/language-tools.md
@@ -18,9 +18,7 @@ Text inputted to grammar, spelling, and style checkers, as well as translation s
 ![LanguageTool logo](assets/img/language-tools/languagetool.svg#only-light){ align=right }
 ![LanguageTool logo](assets/img/language-tools/languagetool-dark.svg#only-dark){ align=right }
 
-**LanguageTool** is a multilingual grammar, style and spell checker that supports more than 20 languages. The software is [self-hostable](https://dev.languagetool.org/http-server), and the extensions do not send your input text to their server.
-
-LanguageTool offers integration with a variety of [office suites](https://languagetool.org/services#text_editors) and [email clients](https://languagetool.org/services#mail_clients).
+**LanguageTool** is a multilingual grammar, style and spell checker that supports more than 20 languages. According to their privacy policy, they do not store any content sent to their service for review, but for higher assurance the software is [self-hostable](https://dev.languagetool.org/http-server).
 
 [:octicons-home-16: Homepage](https://languagetool.org){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://languagetool.org/legal/privacy){ .card-link title="Privacy Policy" }
@@ -41,6 +39,8 @@ LanguageTool offers integration with a variety of [office suites](https://langua
 </details>
 
 </div>
+
+LanguageTool offers integration with a variety of [office suites](https://languagetool.org/services#text_editors) and [email clients](https://languagetool.org/services#mail_clients).
 
 ## Criteria
 


### PR DESCRIPTION
Fixes #2908 

I believe we got this wrong because LanguageTool's privacy policy states this:

>  When you use our Apps and Extensions, **we collect the following information**:
> 
>  -   Date and time of your usage
>   -  Length of the text
>    - Language of the input text (**but not the text itself**) 
> - [...]

However, they appear to be implying "collect _and store_" when they say the word "collect," because I see no indication that any of LanguageTool's capabilities are possible without at least sending the text to their servers. Their Firefox extension description is more clear about this:

> By default, this extension will check your text by sending it to [languagetool.org](https://prod.outgoing.prod.webservices.mozgcp.net/v1/2784e8753205334dfb8b51e670a33f6c9d5820821f44f3d062f81eb2fd45f5ef/https%3A//languagetool.org) over a securely encrypted connection. No account is needed to use this extension. We don't store your IP address. See [https://languagetool.org/privacy/](https://prod.outgoing.prod.webservices.mozgcp.net/v1/852ac1b86c83973f7fe4ded8cc1cda3caa5bbef3a5f1dd9673e883e963e0878d/https%3A//languagetool.org/privacy/) for our privacy policy.