### PR TITLE
update: Remove references to deprecated DNT

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -376,7 +376,7 @@ With the email providers we recommend, we like to see responsible marketing.
 
 **Minimum to Qualify:**
 
-- Must self-host analytics (no Google Analytics, Adobe Analytics, etc.). The provider's site must also comply with [DNT (Do Not Track)](https://en.wikipedia.org/wiki/Do_Not_Track) for those who wish to opt out.
+- Must self-host analytics (no Google Analytics, Adobe Analytics, etc.).
 
 Must not have any irresponsible marketing, which can include the following:
 

--- a/docs/vpn.md
+++ b/docs/vpn.md
@@ -355,7 +355,7 @@ With the VPN providers we recommend we like to see responsible marketing.
 
 **Minimum to Qualify:**
 
-- Must self-host analytics (i.e., no Google Analytics). The provider's site must also comply with [DNT (Do Not Track)](https://en.wikipedia.org/wiki/Do_Not_Track) for people who want to opt out.
+- Must self-host analytics (i.e., no Google Analytics).
 
 Must not have any marketing which is irresponsible:
 


### PR DESCRIPTION
List of changes proposed in this PR:

- DNT is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack) so I removed it from the requirements

Relevant discussion: https://discuss.privacyguides.net/t/remove-references-to-dnt-since-it-s-deprecated/25088

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
