### PR TITLE
docs: Add team members to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,16 +1,22 @@
+# Please use this file to correct information in our git log.
+# Format: Proper Name <Proper Email> <Incorrect Email>
+#
+# Privacy Guides Team Members
+# ===========================
 Daniel Gray <dngray@privacyguides.org> <dng@disroot.org>
 Daniel Gray <dngray@privacyguides.org> <48640805+dngray@users.noreply.github.com>
 Daniel Gray <dngray@privacyguides.org> <dngray@privacytools.io>
 Daniel Gray <dngray@privacyguides.org>
+Em <em@privacyguides.org> <194856901+EmAtPrivacyGuides@users.noreply.github.com>
+Freddy <freddy@privacyguides.org> <freddy@decypher.pw>
+Freddy <freddy@privacyguides.org> <freddy@privacytools.io>
+fria <fria@privacyguides.org> <138676274+friadev@users.noreply.github.com>
 Jonah Aragon <jonah@privacyguides.org> <jonah@triplebit.net>
 Jonah Aragon <jonah@privacyguides.org> <jonah@privacytools.io>
 Jonah Aragon <jonah@privacyguides.org> <github@aragon.science>
-mfwmyfacewhen <mfw@privacyguides.org> <94880365+mfwmyfacewhen@users.noreply.github.com>
-mbananasynergy <mbananasynergy@privacyguides.org> <>
-mbananasynergy <mbananasynergy@privacyguides.org> <107055883+matchboxbananasynergy@users.noreply.github.com>
-rollsicecream <rollsicecream@proton.me> <153316540+rollsicecream@users.noreply.github.com>
-rollsicecream <rollsicecream@proton.me> <waterfallnet@proton.me>
-Freddy <freddy@privacyguides.org> <freddy@decypher.pw>
-Freddy <freddy@privacyguides.org> <freddy@privacytools.io>
+Jordan Warne <jordan@privacyguides.org> <jw@omg.lol>
+Justin Ehrenhofer <justin.ehrenhofer@gmail.com> <12520755+SamsungGalaxyPlayer@users.noreply.github.com>
+Mare Polaris <ph00lt0@privacyguides.org> <15004290+ph00lt0@users.noreply.github.com>
 Niek de Wilde <niek@privacyguides.org> <github.ef27z@simplelogin.com>
 Niek de Wilde <niek@privacyguides.org> <blacklight447@privacytools.io>
+redoomed1 <redoomed1@privacyguides.org> <161974310+redoomed1@users.noreply.github.com>


### PR DESCRIPTION
Team members should use their canonical email addresses rather than noreply.github addresses now that we have a new email setup.

This way we can get accurate statistics when running `git shortlog -nse --group=author --group=trailer:co-authored-by --no-merges` and `git shortlog -nse --group=trailer:signed-off-by`

<img src=https://github.com/user-attachments/assets/19fb7391-22ce-4eb1-87ba-594f7758e018 width=60%>

only spam for the brand new @privacyguides.org accounts of course, the other emails in this file are already public in the git log :P 