### PR TITLE
update: Remove sentence about blocking OCSP checks in macOS

### DIFF
--- a/docs/os/macos-overview.md
+++ b/docs/os/macos-overview.md
@@ -21,8 +21,6 @@ macOS performs online checks when you open an app to verify whether an app conta
 
 Apple's OCSP service uses HTTPS encryption, so only they are able to see which apps you open. They've [posted information](https://support.apple.com/HT202491) about their logging policy for this service. They additionally [promised](http://lapcatsoftware.com/articles/2024/8/3.html) to add a mechanism for people to opt-out of this online check, but this has not been added to macOS.
 
-While you [can](https://eclecticlight.co/2021/02/23/how-to-run-apps-in-private) manually opt out of this check relatively easily, we recommend against doing so unless you would be badly compromised by the revocation checks performed by macOS, because they serve an important role in ensuring compromised apps are blocked from running.
-
 ## Recommended Configuration
 
 Your account when you first set up your Mac will be an Administrator account, which has higher privileges than a Standard user account. macOS has a number of protections which prevent malware and other programs from abusing your Administrator privileges, so it is generally safe to use this account.


### PR DESCRIPTION
List of changes proposed in this PR:

- Removed link to a page recommending blocking OCSP checks and removing signatures from apps in macOS. These checks are an important security feature and shouldn't be removed altogether, as even the blog itself says. Their solution for individual apps to to remove the signature from the app, which prevents the integrity from being checked. On Apple Silicon Macs, it won't even let you run it. There's no [user info](https://support.apple.com/en-us/102445) included in the OCSP checks, and if you want to protect your IP address you should be using a VPN anyway.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
