### PR TITLE
style: Name of V8 setting on Android version of Brave

### DIFF
--- a/docs/mobile-browsers.md
+++ b/docs/mobile-browsers.md
@@ -1,6 +1,6 @@
 ---
 meta_title: "Privacy Respecting Web Browsers for Android and iOS - Privacy Guides"
-title: "Mobile Browsers"
+title: Mobile Browsers
 icon: material/cellphone-information
 description: These browsers are what we currently recommend for standard/non-anonymous internet browsing on your phone.
 cover: mobile-browsers.webp
@@ -167,7 +167,7 @@ Shields' options can be downgraded on a per-site basis as needed, but by default
     - [x] Select **Disable non-proxied UDP** under [*WebRTC IP handling policy*](https://support.brave.com/hc/articles/360017989132-How-do-I-change-my-Privacy-Settings#webrtc)
     - [x] (Optional) Select **No protection** under *Safe Browsing* (1)
     - [ ] Uncheck **Allow sites to check if you have payment methods saved**
-    - [ ] Uncheck **V8 Optimizer** under *Manage V8 security*
+    - [ ] Uncheck **Javascript optimization & security** under the setting with the same name
     - [x] Select **Close tabs on exit**
     - [ ] Uncheck **Allow privacy-preserving product analytics (P3A)**
     - [ ] Uncheck **Automatically send diagnostic reports**


### PR DESCRIPTION
List of changes proposed in this PR:

- Update name of V8 setting (for disabling some parts of JIT) on the Android version of Brave
  - Relevant discussion: https://discuss.privacyguides.net/t/different-name-for-braves-v8-engine-setting-on-android/29036

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
