### PR TITLE
update: Set “Allow Diagnostic Data” to Disabled in Windows LGPO Overview

### DIFF
--- a/docs/os/windows/group-policies.md
+++ b/docs/os/windows/group-policies.md
@@ -83,7 +83,7 @@ Despite the names of these policies, this doesn't *require* you to do anything b
 
 #### Data Collection and Preview Builds
 
-- Allow Diagnostic Data: **Enabled**
+- Allow Diagnostic Data: **Disabled**
     - Options: **Send required diagnostic data** (Pro Edition); or
     - Options: **Diagnostic data off** (Enterprise or Education Edition)
 - Limit Diagnostic Log Collection: **Enabled**


### PR DESCRIPTION
This PR changes the recommended setting for Allow Diagnostic Data from Enabled to Disabled to better align with privacy-focused practices. Disabling this setting reduces the amount of diagnostic data sent to Microsoft, which is more appropriate for users seeking minimal data sharing.