### PR TITLE
update: PeekYou Opt Out links

### DIFF
--- a/docs/data-broker-removals.md
+++ b/docs/data-broker-removals.md
@@ -34,7 +34,7 @@ You should search for your information on these sites first, and submit an opt-o
 - Dataveria ([Search](https://dataveria.com), [Opt-Out](https://dataveria.com/ng/control/privacy))
 - InfoTracer ([Search](https://infotracer.com), [Opt-Out](https://infotracer.com/optout))
 - Intelius ([Search](https://intelius.com), [Opt-Out](https://suppression.peopleconnect.us/login))
-- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/optout))
+- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/ccpa_optout/do_not_sell))
 - PublicDataUSA ([Search](https://publicdatausa.com), [Opt-Out](https://publicdatausa.com/remove.php))
 - Radaris ([Search](https://radaris.com), [Opt-Out](https://radaris.com/page/how-to-remove))
 - Spokeo ([Search](https://spokeo.com/search), [Opt-Out](https://spokeo.com/optout))
@@ -84,7 +84,7 @@ Our [testing](https://www.privacyguides.org/articles/2025/02/03/easyoptouts-revi
 EasyOptOuts does not cover the following sites we consider to be "high priority," so you should still manually opt-out of:
 
 - Intelius ([Search](https://intelius.com), [Opt-Out](https://suppression.peopleconnect.us/login))
-- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/optout))
+- PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/ccpa_optout/do_not_sell))
 
 </div>
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Update the opt out links for PeekYou since the current ones direct to a 404
  - Relevant discussion: https://discuss.privacyguides.net/t/peekyou-opt-out-link-not-accurate-anymore/29207

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
