### PR TITLE
update: Nitrokey section

### DIFF
--- a/docs/security-keys.md
+++ b/docs/security-keys.md
@@ -85,7 +85,7 @@ The firmware of YubiKey is not updatable. If you want features in newer firmware
   ![Nitrokey](assets/img/security-keys/nitrokey.jpg){ width="300" }
 </figure>
 
-**Nitrokey** has a security key capable of [FIDO2 and WebAuthn](basics/multi-factor-authentication.md#fido-fast-identity-online) called the **Nitrokey FIDO2**. For PGP support, you need to purchase one of their other keys such as the **Nitrokey Start**, **Nitrokey Pro 2**, or the **Nitrokey Storage 2**.
+The **Nitrokey 3A Mini** [has FIDO Authenticator Level 1 Certification](https://www.nitrokey.com/news/2024/nitrokey-3a-mini-receives-official-fido2-certification). The Nitrokey 3 Series in general has a wide range of features such as [Universal 2nd Factor (U2F)](https://en.wikipedia.org/wiki/Universal_2nd_Factor), [FIDO2 and WebAuthn](basics/multi-factor-authentication.md#fido-fast-identity-online), Personal Identity Verification (PIV), OpenPGP, and TOTP and HOTP authentication.
 
 [:octicons-home-16: Homepage](https://nitrokey.com){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://nitrokey.com/data-privacy-policy){ .card-link title="Privacy Policy" }
@@ -95,23 +95,26 @@ The firmware of YubiKey is not updatable. If you want features in newer firmware
 
 </div>
 
-The [comparison table](https://nitrokey.com/products/nitrokeys) shows how the different Nitrokey models compare to each other in terms of features and other specifications. The **Nitrokey 3** listed will have a combined feature set.
+The [comparison table](https://nitrokey.com/products/nitrokeys) shows how the different Nitrokey models compare to each other in terms of features and other specifications.
 
 Nitrokey models can be configured using the [Nitrokey app](https://nitrokey.com/download).
 
-For the models which support HOTP and TOTP, there are 3 slots for HOTP and 15 for TOTP. Some Nitrokeys can act as a password manager. They can store 16 different credentials and encrypt them using the same password as the OpenPGP interface.
+The Nitrokey 3 Series can act as a password manager. They can store up to 50 different entries, and each entry can contain login, password, comment and OTP.
 
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
 
-While Nitrokeys do not release the HOTP/TOTP secrets to the device they are plugged into, the HOTP and TOTP storage is **not** encrypted and is vulnerable to physical attacks. If you are looking to store HOTP or TOTP secrets, we highly recommend that you use a YubiKey instead.
+Excluding the Nitrokey 3, Nitrokeys with HOTP and TOTP storage do not have it encrypted, making them vulnerable to physical attacks.
 
 </div>
 
-<div class="admonition warning" markdown>
-<p class="admonition-title">Warning</p>
+**Nitrokey** also has the **Nitrokey Passkey**, a lower-price security key capable of [FIDO2 and WebAuthn](basics/multi-factor-authentication.md#fido-fast-identity-online). This key provides only basic FIDO2 functionality, but for most people that is all you will need. Some notable features the Security Key series does **not** have include:
 
-Resetting the OpenPGP interface on a Nitrokey [Pro 2](https://docs.nitrokey.com/nitrokeys/pro/factory-reset) or Nitrokey [Start 2](https://docs.nitrokey.com/nitrokeys/storage/factory-reset) will also make the password database inaccessible.
+- Password Manager
+- PIV
+- OpenPGP
+- Tamper-resistant smart card
+- TOTP and HOTP
 
 </div>
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Relevant discussion: https://discuss.privacyguides.net/t/mention-nitrokey-3as-fido2-certification/20620 
- Include Nitrokey 3A Mini's FIDO Level 2 Certification, the Nitrokey 3 series in general, and the Nitrokey Passkey
- Remove mentions of obsolete Nitrokey models, and make details more accurate to current models
