### PR TITLE
Replace single quote env var with double quote

### DIFF
--- a/includes/strings.en.env
+++ b/includes/strings.en.env
@@ -1,5 +1,5 @@
 ANALYTICS_FEEDBACK_NEGATIVE_NAME="This page could be improved"
-ANALYTICS_FEEDBACK_NEGATIVE_NOTE='Thanks for your feedback! If you want to let us know more, please leave a post on our <a href="https://discuss.privacyguides.net/c/site-development/7" target="_blank" rel="noopener">forum</a>.'
+ANALYTICS_FEEDBACK_NEGATIVE_NOTE="Thanks for your feedback! If you want to let us know more, please leave a post on our <a href='https://discuss.privacyguides.net/c/site-development/7' target='_blank' rel='noopener'>forum</a>."
 ANALYTICS_FEEDBACK_POSITIVE_NAME="This page was helpful"
 ANALYTICS_FEEDBACK_POSITIVE_NOTE="Thanks for your feedback!"
 ANALYTICS_FEEDBACK_TITLE="Was this page helpful?"


### PR DESCRIPTION
Changed the env var to use double quotes around the value and single quotes in the HTML attributes to avoid issues caused by words containing apostrophes within the text.