### PR TITLE
feat: Add sitewide announcements bar

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,7 +51,7 @@
             {
               "label": "Main",
               "type": "shell",
-              "command": "./run.sh --cmd=mkdocs --insiders --production",
+              "command": "./run.sh --cmd=mkdocs --insiders",
               "group": "test",
               "runOptions": {
                 "runOn": "folderOpen"

--- a/mkdocs.blog.yml
+++ b/mkdocs.blog.yml
@@ -29,8 +29,10 @@ edit_uri_template: blob/main/blog/{path}?plain=1
 extra:
   scope: /
   ghost:
-    data_host: https://www.privacyguides.org/.ghost/analytics/api/v1/page_hit
+    base_url: https://www.privacyguides.org
+    admin_url: https://ghost.privacyguides.org/ghost
     tb_site_uuid: 5f3bdb03-a1af-4844-85ca-cbc82c89eb9a
+    content_api_key: da9d77deb3e85ee73925167f3a
   privacy_guides:
     footer:
       intro:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,8 +39,10 @@ extra:
   offline: !ENV [BUILD_OFFLINE, false]
   deploy: !ENV DEPLOY_ID
   ghost:
-    data_host: https://www.privacyguides.org/.ghost/analytics/api/v1/page_hit
+    base_url: https://www.privacyguides.org
+    admin_url: https://ghost.privacyguides.org/ghost
     tb_site_uuid: 5f3bdb03-a1af-4844-85ca-cbc82c89eb9a
+    content_api_key: da9d77deb3e85ee73925167f3a
   privacy_guides:
     footer:
       intro:

--- a/theme/assets/stylesheets/extra.css
+++ b/theme/assets/stylesheets/extra.css
@@ -46,6 +46,7 @@
     --pg-green: #2e7e31;
     --pg-blue-gray: #546d78;
     --pg-viridian: #40826d;
+    --ghost-accent-color: #4f46e5;
 }
 :root, [data-md-color-scheme="slate"] {
     --md-default-bg-color: rgb(26, 26, 27);
@@ -67,6 +68,7 @@
     --pg-blue-gray: #9ab2bc;
     --pg-viridian: #40826d;
     --md-footer-bg-color--dark: var(--md-default-bg-color);
+    --ghost-accent-color: #4f46e5;
 }
 
 /* Better contrast link colors */

--- a/theme/main.html
+++ b/theme/main.html
@@ -87,17 +87,34 @@
     <meta name="robots" content="max-snippet:-1, max-image-preview:large">
   {% endif %}
 
+  {% if not config.extra.offline %}
+  <script defer src="https://cdn.jsdelivr.net/ghost/portal@2.53.2/umd/portal.min.js"
+          data-i18n="true"
+          data-ghost="{{ config.extra.ghost.base_url }}/"
+          data-key="{{ config.extra.ghost.content_api_key }}"
+          data-api="{{ config.extra.ghost.admin_url }}/api/content/"
+          data-locale="{{ config.theme.language }}"
+          data-members-signin-otc="false"
+          crossorigin="anonymous">
+  </script>
+  <script defer src="https://cdn.jsdelivr.net/ghost/announcement-bar@~1.1/umd/announcement-bar.min.js"
+          data-announcement-bar="{{ config.extra.ghost.base_url }}/"
+          data-api-url="{{ config.extra.ghost.base_url }}/members/api/announcement/"
+          crossorigin="anonymous">
+  </script>
+  {% endif %}
+
   {% if config.extra.context == "production" %}
 
-    <link href="https://www.privacyguides.org/webmentions/receive/" rel="webmention">
+    <link href="{{ config.extra.ghost.base_url }}/webmentions/receive/" rel="webmention">
     <meta http-equiv="onion-location" content="{{ page.canonical_url | replace("https://www.privacyguides.org", "http://www.xoe4vn5uwdztif6goazfbmogh6wh5jc4up35bqdflu6bkdc5cas5vjqd.onion") }}" />
 
     {% if config.theme.language == "en" %}
-      <script defer src="/public/ghost-stats.min.js?v=8037af1487"
+      <script defer src="{{ config.extra.ghost.base_url }}/public/ghost-stats.min.js?v=8037af1487"
               data-stringify-payload="false"
               data-datasource="analytics_events"
               data-storage="localStorage"
-              data-host="{{ config.extra.ghost.data_host }}"
+              data-host="{{ config.extra.ghost.base_url }}/.ghost/analytics/api/v1/page_hit"
               tb_site_uuid="{{ config.extra.ghost.tb_site_uuid }}"
               tb_post_uuid="undefined"
               tb_post_type="null"
@@ -113,13 +130,4 @@
   {{ page.meta.schema|tojson }}
   </script>
   {% endif %}
-  <script defer src="https://cdn.jsdelivr.net/ghost/portal@2.53.2/umd/portal.min.js"
-          data-i18n="true"
-          data-ghost="https://www.privacyguides.org/"
-          data-key="da9d77deb3e85ee73925167f3a"
-          data-api="https://ghost.privacyguides.org/ghost/api/content/"
-          data-locale="{{ config.theme.language }}"
-          data-members-signin-otc="false"
-          crossorigin="anonymous">
-  </script>
 {% endblock %}


### PR DESCRIPTION
We can pull data from Ghost to display temporary announcements sitewide if we'd like, e.g.:

<img width="3054" height="1136" alt="2025-09-12 at 17 34 46" src="https://github.com/user-attachments/assets/d1fef73b-d1dc-4194-b565-a9f0495e36a8" />