### PR TITLE
fix(blog): Shorten meta descriptions under 300 characters

### DIFF
--- a/blog/posts/age-verification-wants-your-face.md
+++ b/blog/posts/age-verification-wants-your-face.md
@@ -5,7 +5,7 @@ categories:
     - News
 authors:
     - em
-description: Age verification laws and propositions forcing platforms to restrict content accessed by children and teens have been multiplying in recent years. The problem is, implementing such measure necessarily requires identifying each user accessing this content, one way or another. This is bad news for your privacy.
+description: Age verification laws forcing platforms to restrict access to content online have been multiplying in recent years. The problem is, implementing such measure necessarily requires identifying each user accessing this content, one way or another. This is bad news for your privacy.
 schema_type: AnalysisNewsArticle
 preview:
   cover: blog/assets/images/age-verification-wants-your-face/ageverification-cover.webp

--- a/blog/posts/cryptpad-review.md
+++ b/blog/posts/cryptpad-review.md
@@ -9,7 +9,7 @@ categories:
     - Reviews
 authors:
     - em
-description: "If you have been looking for a privacy-respectful replacement to Google Docs, now is the time to switch to the end-to-end encrypted office suite CryptPad."
+description: If you've been looking for a privacy-respectful replacement to Google Docs, now is the time to switch to the end-to-end encrypted office suite CryptPad.
 preview:
   logo: theme/assets/img/document-collaboration/cryptpad.svg
 review:

--- a/blog/posts/encryption-is-not-a-crime.md
+++ b/blog/posts/encryption-is-not-a-crime.md
@@ -5,7 +5,7 @@ categories:
     - Opinion
 authors:
     - em
-description: Encryption is not a crime, encryption protects all of us. Encryption, and especially end-to-end encryption, is an essential tool to protect everyone online. Attempts to undermine encryption are an attack to our fundamental right to privacy and an attack to our inherent right to security and safety.
+description: Encryption is not a crime, encryption protects us all. Encryption, and especially end-to-end encryption, is an essential tool to protect everyone online. Attempts to undermine encryption are an attack to our fundamental right to privacy and an attack to our inherent right to security and safety.
 schema_type: OpinionNewsArticle
 preview:
   cover: blog/assets/images/encryption-is-not-a-crime/encryption-is-not-a-crime-cover.webp

--- a/blog/posts/importance-of-privacy-for-the-queer-community.md
+++ b/blog/posts/importance-of-privacy-for-the-queer-community.md
@@ -7,7 +7,7 @@ tags:
     - Pride Month
 authors:
     - em
-description: Data privacy is important for everyone. But for some marginalized populations, data privacy is indispensable for social connection, access to information, and physical safety. For Pride month this year, we will discuss topics at the intersection of data privacy and experiences specific to the LGBTQ+ community.
+description: Data privacy is important for everyone. But for some marginalized populations, data privacy is indispensable for social connection, access to information, and physical safety. For Pride month, we discuss topics at the intersection of data privacy and experiences specific to the LGBTQ+ community.
 schema_type: AnalysisNewsArticle
 preview:
   cover: blog/assets/images/importance-of-privacy-for-the-queer-community/pride-cover.webp

--- a/blog/posts/in-praise-of-tor.md
+++ b/blog/posts/in-praise-of-tor.md
@@ -8,7 +8,7 @@ tags:
     - Tor
 authors:
     - em
-description: You might have heard of Tor in the news a few times, yet never dared to try it yourself. Despite being around for decades, Tor is still a tool too few people know about. Today, Tor is easy to use for anyone. It not only helps journalists and activists, but anybody who seeks greater privacy online or access to information regardless of location. But what is Tor exactly? How can Tor help you? And why is it such an important tool?
+description: You might have heard of Tor already, yet never dared to try it yourself. Despite being around for decades, too few people know about Tor. It isn't only a tool for journalists and activists, but for anyone seeking greater privacy online. What is Tor exactly? And how can Tor help you?
 schema_type: OpinionNewsArticle
 preview:
   cover: blog/assets/images/in-praise-of-tor/tor-cover.webp

--- a/blog/posts/keepassium-review.md
+++ b/blog/posts/keepassium-review.md
@@ -8,7 +8,7 @@ categories:
     - Reviews
 authors:
     - em
-description: "If you need a password manager for iOS or macOS that gives you full control over your data, KeePassium is a fantastic option. KeePassium offers some synchronization features, but keeps your password database offline by default. You choose who to trust to store your passwords, and you can change it whenever you want."
+description: If you need a password manager for iOS or macOS that gives you full control over your data, KeePassium is a fantastic option. With KeePassium, you can keep your password database offline entirely, or choose whomever you trust to store it. You can also change this anytime.
 preview:
   logo: blog/assets/images/keepassium-review/keepassium.svg
 review:

--- a/blog/posts/sam-altman-wants-your-eyeball.md
+++ b/blog/posts/sam-altman-wants-your-eyeball.md
@@ -6,7 +6,7 @@ categories:
     - News
 authors:
     - em
-description: Last week, OpenAI's CEO Sam Altman announced in San Francisco that the World project he co-founded, formerly known as Worldcoin, is opening six stores across the United States, allowing users of the project's app to scan their eyeballs.
+description: Last week, OpenAI's CEO Sam Altman announced in San Francisco that the World project he co-founded, formerly known as Worldcoin, is opening six stores across the United States, allowing users of the project's app to scan their eyeballs. This is worrisome, to say the least.
 schema_type: AnalysisNewsArticle
 preview:
   cover: blog/assets/images/sam-altman-wants-your-eyeball/orb-cover.webp

--- a/blog/posts/selling-surveillance-as-convenience.md
+++ b/blog/posts/selling-surveillance-as-convenience.md
@@ -5,7 +5,7 @@ categories:
     - Opinion
 authors:
     - em
-description: Increasingly, surveillance is being normalized and integrated in our lives. Under the guise of convenience, applications and features are sold to us as being the new better way to do things. While some might be useful, this convenience is a Trojan horse. The cost of it is the continuous degradation of our privacy rights, with all that that entails.
+description: Increasingly, surveillance is being normalized and integrated in our lives. Under the guise of convenience, applications and features are sold to us as being the new better way to do things. But this convenience is a Trojan horse.
 schema_type: OpinionNewsArticle
 preview:
   cover: blog/assets/images/selling-surveillance-as-convenience/surveillance-cover.webp

--- a/blog/posts/the-future-of-privacy.md
+++ b/blog/posts/the-future-of-privacy.md
@@ -5,7 +5,7 @@ categories:
     - News
 authors:
     - em
-description: Privacy is intrinsically intertwined with politics. Each change in governance can have serious effects on privacy rights and privacy tools, for better or for worse. Let's examine with concrete examples how politics affect legislations that can have an immense impact on the privacy tools and features we use.
+description: Privacy is intrinsically intertwined with politics. Each change in governance can have substantial effects on privacy rights and privacy tools. Using concrete examples, we examine how politics can impact the tools we use.
 schema_type: NewsArticle
 preview:
   cover: blog/assets/images/the-future-of-privacy/cover.webp

--- a/blog/posts/the-privacy-of-others.md
+++ b/blog/posts/the-privacy-of-others.md
@@ -5,7 +5,7 @@ categories:
     - Explainers
 authors:
     - em
-description: In privacy, we talk a lot about how to protect our own data, but what about our responsibility to protect the data of others? If you care about privacy rights, you must also care for the data of the people around you. Together, we must start building a culture of data privacy where everyone cares for the data of others.
+description: In privacy, we talk a lot about how to protect our own data, but what about our responsibility to protect the data of others? If you care about privacy rights, you must also care for the data of the people around you. Together, we must build a culture where everyone cares for the data of others.
 schema_type: NewsArticle
 preview:
   cover: blog/assets/images/the-privacy-of-others/cover.webp

--- a/blog/posts/your-online-life-is-irl.md
+++ b/blog/posts/your-online-life-is-irl.md
@@ -5,7 +5,7 @@ categories:
     - Opinion
 authors:
     - em
-description: If you, like myself, have been inhabiting the internet for a few decades, you're probably familiar with the old adage IRL (In Real Life). The acronym was used a lot when the distinction between online life and offline life was much greater than it is now. In today's world, can we really keep referring to our digital life as being somehow disconnected from our real life?
+description: If you've been on the internet for a while, you're probably familiar with the old adage IRL (In Real Life). The acronym was used a lot when online and offline life was much more separated than it is now. Today, can we truly keep talking about our digital life as being separated from our real life?
 schema_type: OpinionNewsArticle
 preview:
   cover: blog/assets/images/your-online-life-is-irl/irl-cover.webp


### PR DESCRIPTION
List of changes proposed in this PR:

Shorten meta descriptions for articles with descriptions longer than 300 characters* 
Changes include the following articles:

- age-verification-wants-your-face.md
- cryptpad-review.md
- encryption-is-not-a-crime.md
- importance-of-privacy-for-the-queer-community.md
- in-praise-of-tor.md
- keepassium-review.md
- sam-altman-wants-your-eyeball.md (*added to improve)
- selling-surveillance-as-convenience.md
- the-future-of-privacy.md
- the-privacy-of-others.md
- your-online-life-is-irl.md
