### PR TITLE
style: Replace mat2 GitLab links with GitHub links

### DIFF
--- a/docs/data-redaction.md
+++ b/docs/data-redaction.md
@@ -24,19 +24,19 @@ You should **never** use blur to redact [text in images](https://bishopfox.com/b
 
 ![MAT2 logo](assets/img/data-redaction/mat2.svg){ align=right }
 
-**MAT2** is free, cross-platform software which allows you to remove metadata from image, audio, torrent, and document file types. It provides both a command line tool and a graphical user interface via an extension for [Dolphin](https://0xacab.org/jvoisin/mat2/-/tree/master/dolphin), the default file manager of [KDE](https://kde.org).
+**MAT2** is free, cross-platform software which allows you to remove metadata from image, audio, torrent, and document file types. It provides both a command line tool and a graphical user interface via an extension for [Dolphin](https://github.com/jvoisin/mat2/tree/master/dolphin), the default file manager of [KDE](https://kde.org).
 
-[:octicons-repo-16: Repository](https://github.com/jvoisin/mat2){ .md-button .md-button--primary }
-[:octicons-info-16:](https://github.com/jvoisin/mat2/blob/master/README.md){ .card-link title="Documentation" }
+[:octicons-repo-16: Repository](https://github.com/jvoisin/mat2#readme){ .md-button .md-button--primary }
+[:octicons-info-16:](https://github.com/jvoisin/mat2#how-to-use-mat2){ .card-link title="Documentation" }
 [:octicons-code-16:](https://github.com/jvoisin/mat2){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
 <summary>Downloads</summary>
 
-- [:fontawesome-brands-windows: Windows](https://pypi.org/project/mat2#metadata-and-privacy)
-- [:simple-apple: macOS](https://github.com/jvoisin/mat2?tab=readme-ov-file#requirements-setup-on-macos-os-x-using-homebrew)
+- [:fontawesome-brands-windows: Windows](https://pypi.org/project/mat2)
+- [:simple-apple: macOS](https://github.com/jvoisin/mat2#requirements-setup-on-macos-os-x-using-homebrew)
 - [:simple-linux: Linux](https://pypi.org/project/mat2)
-- [:octicons-globe-16: Web](https://github.com/jvoisin/mat2?tab=readme-ov-file#web-interface)
+- [:octicons-browser-16: Web](https://github.com/jvoisin/mat2#web-interface)
 
 </details>
 


### PR DESCRIPTION
List of changes proposed in this PR:

- The [GitLab repo for mat2](https://0xacab.org/jvoisin/mat2) is deprecated, per their README. I replaced the `https://0xacab.org/` links with their GitHub equivalent.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
