### PR TITLE
style: Replace Element Classic download links with Element X links

### DIFF
--- a/docs/social-networks.md
+++ b/docs/social-networks.md
@@ -127,9 +127,9 @@ If you used our recommended configuration settings above, you should be posting 
 <details class="downloads" markdown>
 <summary>Downloads</summary>
 
-- [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=im.vector.app)
-- [:simple-appstore: App Store](https://apps.apple.com/app/id1083446067)
-- [:simple-github: GitHub](https://github.com/element-hq/element-android/releases)
+- [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.element.android.x)
+- [:simple-appstore: App Store](https://apps.apple.com/app/id1631335820)
+- [:simple-github: GitHub](https://github.com/element-hq/element-x-android/releases)
 - [:fontawesome-brands-windows: Windows](https://element.io/download)
 - [:simple-apple: macOS](https://element.io/download)
 - [:simple-linux: Linux](https://element.io/download)


### PR DESCRIPTION
List of changes proposed in this PR:

- Replace the current download links for Element (Classic) with those for Element X
  - According to the [Readme](https://github.com/element-hq/element-android#element-android) of the Element Classic Android repository,
    > [i]t is recommended to use [Element X](https://github.com/element-hq/element-x-android) that is the next-generation mobile app.
  - The repo maintainers also changed the status of the Element X apps: https://github.com/element-hq/element-x-android/commit/d4e49f02db8a118a64b8de2e0287dcc42db2246a https://github.com/element-hq/element-x-ios/commit/e68d38f468c402c558f1aaae1203e5436d7d1ca0.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
