### PR TITLE
update: Remove outdated status of Proton Calendar source code

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -50,14 +50,14 @@ Multiple calendars and extended sharing functionality are limited to paid subscr
 
 ![Proton](assets/img/calendar/proton-calendar.svg){ align=right }
 
-**Proton Calendar** is an encrypted calendar service available to Proton members via web or mobile clients. Features include automatic E2EE of all data, sharing features, import/export functionality, and [more](https://proton.me/support/proton-calendar-guide).
+**Proton Calendar** is an encrypted calendar service available to Proton members via its web or mobile clients. Features include automatic E2EE of all data, sharing features, import/export functionality, and [more](https://proton.me/support/proton-calendar-guide).
 
 Those on the free tier have access to 3 calendars, whereas paid subscribers can create up to 25 calendars. Extended sharing functionality is also limited to paid subscribers.
 
 [:octicons-home-16: Homepage](https://proton.me/calendar){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://proton.me/calendar/privacy-policy){ .card-link title="Privacy Policy" }
 [:octicons-info-16:](https://proton.me/support/calendar){ .card-link title="Documentation" }
-[:octicons-code-16:](https://github.com/ProtonMail/WebClients){ .card-link title="Source Code" }
+[:octicons-code-16:](https://github.com/orgs/ProtonMail/repositories?q=calendar){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
 <summary>Downloads</summary>
@@ -70,7 +70,7 @@ Those on the free tier have access to 3 calendars, whereas paid subscribers can 
 
 </div>
 
-Unfortunately, as of August 2024 Proton has [still](https://discuss.privacyguides.net/t/proton-calendar-is-not-open-source-mobile/14656/8) not released the source code for their mobile Calendar app on Android or iOS, and only the former has been [audited](https://proton.me/blog/security-audit-all-proton-apps). Proton Calendar's web client is open source, however, and has been [audited](https://proton.me/community/open-source).
+In 2021, Securitum [audited](https://proton.me/community/open-source#:~:text=Proton%20Calendar) Proton Calendar's web client and provided a [letter of attestation](https://res.cloudinary.com/dbulfrlrz/images/v1714639870/wp-pme/letter-of-attestation-proton-calendar-20211109_3138998f9b/letter-of-attestation-proton-calendar-20211109_3138998f9b.pdf) for the Android app.
 
 ## Criteria
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Remove the now outdated lines about Proton Calendar's source availability since Proton recently established the GitHub repositories for the iOS and Android apps
  - Relevant discussion: https://discuss.privacyguides.net/t/proton-calendar-android-source-code-published/32548
- Revise line about the software's audit status, as the first link redirects to the second link
  - It looks like the first link, as well as the audit for Proton Calendar's Android app, is no longer published (still viewable via [Wayback Machine](https://web.archive.org/web/20250407171025/https://proton.me/blog/security-audit-all-proton-apps)).
- Replace current source code link (which simply directs to the monorepo) with a link that specifically shows the calendar-specific repos at a glance

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
