### PR TITLE
style: Move iOS Passwords out of desktop section in Account Deletion article

### DIFF
--- a/docs/basics/account-deletion.md
+++ b/docs/basics/account-deletion.md
@@ -15,7 +15,7 @@ If you have a password manager that you've used for your entire digital life, th
   ![Bitwarden's Data Breach Report feature](../assets/img/account-deletion/exposed_passwords.png)
 </figure>
 
-Even if you haven't explicitly used a password manager before, there's a chance you've used the one in your browser ([Firefox](https://support.mozilla.org/kb/password-manager-remember-delete-edit-logins), [Chrome](https://passwords.google.com/intro), [Edge](https://support.microsoft.com/microsoft-edge/save-or-forget-passwords-in-microsoft-edge-b4beecb0-f2a8-1ca0-f26f-9ec247a3f336)) or your phone ([Google](https://passwords.google.com/intro)) on stock Android, [Passwords](https://support.apple.com/HT211146) on iOS) without even realizing it.
+Even if you haven't explicitly used a password manager before, there's a chance you've used the one in your browser ([Firefox](https://support.mozilla.org/kb/password-manager-remember-delete-edit-logins), [Chrome](https://passwords.google.com/intro), [Edge](https://support.microsoft.com/microsoft-edge/save-or-forget-passwords-in-microsoft-edge-b4beecb0-f2a8-1ca0-f26f-9ec247a3f336)) or your phone ([Google](https://passwords.google.com/intro) on stock Android, [Passwords](https://support.apple.com/HT211146) on iOS) without even realizing it.
 
 Desktop platforms also often have a password manager which may help you recover passwords you've forgotten about:
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Move mention of iOS Passwords out of the list of desktop platforms in the Password Manager section of the Account Deletion article
  - Relevant discussion: https://discuss.privacyguides.net/t/ios-isnt-a-desktop-platform/32916
- Make minor formatting and grammar improvements

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
