### PR TITLE
Update out of date statement about Arkenfox fingerprinting protection relative to Mullvad Browser

### DIFF
--- a/docs/desktop-browsers.md
+++ b/docs/desktop-browsers.md
@@ -222,7 +222,7 @@ Max Protection enforces the use of DNS over HTTPS, and a security warning will s
 <div class="admonition tip" markdown>
 <p class="admonition-title">Use Mullvad Browser for advanced anti-fingerprinting</p>
 
-[Mullvad Browser](#mullvad-browser) provides the same anti-fingerprinting protections as Arkenfox out of the box, and does not require the use of Mullvad's VPN to benefit from these protections. Coupled with a VPN, Mullvad Browser can thwart more advanced tracking scripts which Arkenfox cannot. Arkenfox still has the advantage of being much more flexible, and allowing per-site exceptions for websites which you need to stay logged in to.
+[Mullvad Browser](#mullvad-browser) provides stronger anti-fingerprinting protections than Arkenfox out of the box, and does not require the use of Mullvad's VPN to benefit from these protections. Coupled with a VPN, Mullvad Browser can thwart more advanced tracking scripts which Arkenfox cannot. Arkenfox still has the advantage of being much more flexible, and allowing per-site exceptions for websites which you need to stay logged in to.
 
 </div>
 


### PR DESCRIPTION
Arkenfox now uses FPP by default, not RFP which is used by Tor Browser and Mullvad Browser. RFP is the stronger feature.

This commit updates our language to reflect that Mullvad (and Tor Browser) have stronger anti-fingerprinting protection than Arkenfox out of the box.

List of changes proposed in this PR:

- Changes:
   * Replaces:  "Mullvad Browser provides **the same** anti-fingerprinting protections **as** Arkenfox out of the box"
   * With: "Mullvad Browser provides **stronger** anti-fingerprinting protections **than** Arkenfox out of the box"