### PR TITLE
update: Remove Dataveria from list of people search sites

### DIFF
--- a/docs/data-broker-removals.md
+++ b/docs/data-broker-removals.md
@@ -31,7 +31,6 @@ You should search for your information on these sites first, and submit an opt-o
 - BeenVerified ([Search](https://beenverified.com/app/optout/search), [Opt-Out](https://beenverified.com/app/optout/address-search))
 - CheckPeople ([Search](https://checkpeople.com/do-not-sell-info), select *Remove Record* to opt-out)
 - ClustrMaps ([Search](https://clustrmaps.com), [Opt-Out](https://clustrmaps.com/bl/opt-out))
-- Dataveria ([Search](https://dataveria.com), [Opt-Out](https://dataveria.com/ng/control/privacy))
 - InfoTracer ([Search](https://infotracer.com), [Opt-Out](https://infotracer.com/optout))
 - Intelius ([Search](https://intelius.com), [Opt-Out](https://suppression.peopleconnect.us/login))
 - PeekYou ([Search](https://peekyou.com), [Opt-Out](https://peekyou.com/about/contact/ccpa_optout/do_not_sell))


### PR DESCRIPTION
List of changes proposed in this PR:

- Remove defunct people search site Dataveria from list on Data Removal Services page
  - Yael Grauer's list also removed this site: https://github.com/yaelwrites/Big-Ass-Data-Broker-Opt-Out-List/commit/81e92e17e9bde3a4ab234ccec1fbf3782b9c1797

Closes #3180 

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
