### PR TITLE
style: Clarify E2EE wording in intro to Calendar Sync page

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -9,7 +9,7 @@ cover: calendar.webp
 - [:material-bug-outline: Passive Attacks](basics/common-threats.md#security-and-privacy){ .pg-orange }
 - [:material-server-network: Service Providers](basics/common-threats.md#privacy-from-service-providers){ .pg-teal }
 
-**Calendars** contain some of your most sensitive data; use products that implement end-to-end encryption at rest to prevent a provider from reading them.
+**Calendars** contain some of your most sensitive data; use products that implement end-to-end encryption to prevent a provider from reading them.
 
 ## Tuta
 


### PR DESCRIPTION
Replace "products that implement end-to-end encryption at rest" with "products that implement end-to-end encryption" since "at rest" is not meaningful in this context. As you know, encryption at rest should not be confused with end-to-end encryption.