### PR TITLE
update: Remove mention of Machine-ID in Linux Overview

### DIFF
--- a/docs/os/linux-overview.md
+++ b/docs/os/linux-overview.md
@@ -159,7 +159,6 @@ There are other system identifiers which you may wish to be careful about. You s
 
 - **Hostnames:** Your system's hostname is shared with the networks you connect to. You should avoid including identifying terms like your name or operating system in your hostname, instead sticking to generic terms or random strings.
 - **Usernames:** Similarly, your username is used in a variety of ways across your system. Consider using generic terms like "user" rather than your actual name.
-- **Machine ID:** During installation, a unique machine ID is generated and stored on your device. Consider [setting it to a generic ID](https://madaidans-insecurities.github.io/guides/linux-hardening.html#machine-id).
 
 ### System Counting
 


### PR DESCRIPTION
- Machine ID uniqueness may be desired. See: https://github.com/secureblue/secureblue/issues/1121 and https://gitlab.tails.boum.org/tails/tails/-/issues/7100.
  - TL;DR of both links is: having a static machine-id makes it easier to identify that a machine is, for example, running the Tails OS.
  - It may also cause breakage on systemd-creds encryption: https://github.com/secureblue/secureblue/issues/1121#issuecomment-3054194314 (not confirmed, though)

---------------
I declare that I have no conflict of interest by sending this PR.