### PR TITLE
update: Add Firefox's daily usage ping item

### DIFF
--- a/docs/desktop-browsers.md
+++ b/docs/desktop-browsers.md
@@ -180,9 +180,11 @@ This protects you from persistent cookies, but does not protect you against cook
 
 ##### Telemetry
 
-- [ ] Uncheck **Allow Firefox to send technical and interaction data to Mozilla**
-- [ ] Uncheck **Allow Firefox to install and run studies**
-- [ ] Uncheck **Allow Firefox to send backlogged crash reports on your behalf**
+- [ ] Uncheck **Send technical and interaction data to Mozilla**
+- [ ] Uncheck **Allow personalized extension recommendations**
+- [ ] Uncheck **Install and run studies**
+- [ ] Uncheck **Send daily usage ping to Mozilla**
+- [ ] Uncheck **Automatically send crash reports**
 
 According to Mozilla's privacy policy for Firefox,
 


### PR DESCRIPTION
Firefox has introduced daily usage pings to Mozilla and published documentation on how to opt out: https://support.mozilla.org/en-US/kb/usage-ping-settings#w_how-can-i-opt-out
This PR updates the Telemetry section to reflect this change.

List of changes proposed in this PR:

- Added "Send daily usage ping to Mozilla" option
- Updated text for other items in the Telemetry section

The updated text is shown in the screenshot below:
<img width="966" height="460" alt="image" src="https://github.com/user-attachments/assets/0abe4ee2-19a3-41fc-ba78-eaa8d6a5b592" />
