### PR TITLE
fix: Social cards and bios for activism section

### DIFF
--- a/blog/author/em.md
+++ b/blog/author/em.md
@@ -1,5 +1,5 @@
 ---
-description: Em is a full-time journalist at Privacy Guides.
+description: Em is the Activism & Outreach Lead at Privacy Guides. She is a public‑interest technologist and researcher who has been working on various independent projects in data privacy, information security, and software engineering since 2018.
 schema:
   -
     "@context": https://schema.org
@@ -25,7 +25,7 @@ schema:
 
 ![Profile picture](https://github.com/EmAtPrivacyGuides.png){ align=right }
 
-[**Em**](https://emontheinternet.me/) is a full-time staff writer at *Privacy Guides*. She is a public‑interest technologist and researcher who has been working on various independent projects in data privacy, information security, and software engineering since 2018.
+[**Em**](https://emontheinternet.me/) is the Activism & Outreach Lead at *Privacy Guides*. She is a public‑interest technologist and researcher who has been working on various independent projects in data privacy, information security, and software engineering since 2018.
 
 Em is passionate about digital rights, privacy advocacy, solid security, and code for the public good. In her free time, you can find Em on Mastodon giving privacy tips or boosting photos of cats and moss.
 

--- a/blog/author/jonah.md
+++ b/blog/author/jonah.md
@@ -1,5 +1,5 @@
 ---
-description: Jonah Aragon is the Project Director and staff writer at Privacy Guides. His role includes researching and writing for this website, system administration, creating Privacy Guides Online Learning course content, reviewing the products recommended here, and most other day-to-day tasks.
+description: Jonah is Privacy Guides' editor and Program Director. With over a decade of technical writing experience, his role includes researching and writing for Privacy Guides. He also runs Triplebit, a non-profit ISP behind many privacy-related tools.
 schema:
   -
     "@context": https://schema.org
@@ -29,9 +29,7 @@ schema:
 
 ![Profile picture](https://github.com/jonaharagon.png){ align=right }
 
-[**Jonah Aragon**](https://www.jonaharagon.com) is the Project Director and staff writer at *Privacy Guides*. His role includes researching and writing for this website, system administration, creating Privacy Guides Online Learning course content, reviewing the products recommended here, and most other day-to-day tasks.
-
-He is also known for his work on the Techlore YouTube channel, including the Techlore Talks podcast he co-hosts.
+[**Jonah Aragon**](https://www.jonaharagon.com) is *Privacy Guides'* editor and Program Director. With over a decade of technical writing experience, his role includes researching and writing for Privacy Guides. He also runs Triplebit, a non-profit ISP behind many privacy-related tools.
 
 [:simple-mastodon: @jonah@neat.computer](https://mastodon.neat.computer/@jonah "@jonah@neat.computer"){ .md-button rel=me }
 [:simple-bluesky: @jonaharagon.com](https://bsky.app/profile/jonaharagon.com "@jonaharagon.com"){ .md-button rel=me }

--- a/docs/about.md
+++ b/docs/about.md
@@ -128,7 +128,7 @@ Our staff are paid to contribute to supplemental content at Privacy Guides, like
 
     ---
 
-    :material-text-account: Staff Writer
+    :material-text-account: Activism and Outreach
 
     [:material-account: Profile](https://discuss.privacyguides.net/u/em)
 
@@ -147,18 +147,6 @@ Our staff are paid to contribute to supplemental content at Privacy Guides, like
     [:material-github:](https://github.com/jordan-warne "GitHub")
     [:material-mastodon:](https://social.lol/@jw "@jw@social.lol"){rel=me}
     [:material-email:](mailto:jordan@privacyguides.org "Email")
-
--   :japanese_goblin:{ .lg .middle } **Kevin Pham**
-
-    ---
-
-    :material-text-account: Community & News Intern
-
-    [:material-account: Profile](https://discuss.privacyguides.net/u/kevpham)
-
-    [:material-github:](https://github.com/kevpham123 "GitHub")
-    [:material-mastodon:](https://mastodon.social/@kevpham "@kevpham@mastodon.social"){rel=me}
-    [:material-email:](mailto:kevin@privacyguides.org "Email")
 
 -   :video_camera:{ .lg .middle } **Nate Bartram**
 

--- a/docs/activism/toolbox/.meta.yml
+++ b/docs/activism/toolbox/.meta.yml
@@ -1,2 +1,4 @@
 hide:
   - toc
+social:
+  cards_layout: toolbox

--- a/mkdocs.blog.yml
+++ b/mkdocs.blog.yml
@@ -219,6 +219,7 @@ nav:
       !ENV [MAIN_SITE_KNOWLEDGE_BASE_URL, "/en/basics/why-privacy-matters/"]
   - !ENV [NAV_RECOMMENDATIONS, "Recommendations"]:
       !ENV [MAIN_SITE_RECOMMENDATIONS_URL, "/en/tools/"]
+  - !ENV [NAV_ACTIVISM, "Activism"]: !ENV [MAIN_SITE_ACTIVISM_URL, "/activism/"]
   - !ENV [NAV_BLOG, "Articles"]:
       - Latest Posts: !ENV [ARTICLES_SITE_BASE_URL, "index.md"]
       - index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -292,7 +292,7 @@ theme:
     - search.highlight
 
 extra_css:
-  - assets/stylesheets/extra.css?v=20250723
+  - assets/stylesheets/extra.css?v=20260303
 extra_javascript:
   - path: assets/javascripts/randomize-element.js?v=20250306
     defer: true

--- a/theme/layouts/toolbox.yml
+++ b/theme/layouts/toolbox.yml
@@ -1,0 +1,155 @@
+definitions:
+  - &background_image >-
+    {%- if page.meta.cover -%}
+      theme/assets/img/cover/{{ page.meta.cover }}
+    {%- else -%}
+      {{ layout.background_image or "" }}
+    {%- endif -%}
+
+  - &background_color >-
+    {%- if page.meta.cover -%}
+      #f7f7fcaa
+    {%- else -%}
+      #FFD06F
+    {%- endif -%}
+
+  - &color >-
+    {{ layout.color or "#2d2d2d" }}
+
+  - &title_font_family >-
+    {%- if config.theme.language == "he" -%}
+      Suez One
+    {%- elif config.theme.language == ("ru" or "zh-Hant" or "zh-TW") -%}
+      Noto Serif TC
+    {%- else -%}
+      Bagnard
+    {%- endif -%}
+
+  - &title_font_style >-
+    {%- if config.theme.language == "he" -%}
+      Regular
+    {%- else -%}
+      Bold
+    {%- endif -%}
+
+  - &font_family >-
+    {%- if config.theme.language == "he" -%}
+      Suez One
+    {%- elif config.theme.language == ("ru" or "zh-Hant" or "zh-TW") -%}
+      Noto Sans TC
+    {%- else -%}
+      Public Sans
+    {%- endif -%}
+
+  - &site_name >-
+    {{ config.site_name }}
+
+  - &page_title >-
+    {{ page.meta.get("title", page.title) }}
+
+  - &page_title_with_site_name >-
+    {%- if page.meta.meta_title -%}
+      {{ page.meta.meta_title }}
+    {%- else -%}
+      {{ page.meta.get("title", page.title) }} - {{ config.site_name }}
+    {%- endif -%}
+
+  - &page_description >-
+    {{ page.meta.get("description", config.site_description) or "" }}
+
+  - &page_icon >-
+    {{ page.meta.icon or "" }}
+
+  - &logo >-
+    theme/assets/brand/logos/svg/logo/privacy-guides-logo-notext-colorbg.svg
+
+# Meta tags
+tags:
+  # Open Graph
+  og:site_name: *site_name
+  og:type: website
+  og:title: *page_title_with_site_name
+  og:description: *page_description
+  og:image: "{{ image.url }}"
+  og:image:type: "{{ image.type }}"
+  og:image:width: "{{ image.width }}"
+  og:image:height: "{{ image.height }}"
+  og:url: "{{ page.canonical_url }}"
+
+  # Facebook
+  article:publisher: "https://www.facebook.com/PrivacyGuides.org"
+
+  # Mastodon
+  fediverse:creator: "@privacyguides@neat.computer"
+
+  # Twitter
+  twitter:site: "@privacy_guides"
+  twitter:card: summary_large_image
+  twitter:title: *page_title_with_site_name
+  twitter:description: *page_description
+  twitter:image: "{{ image.url }}"
+  twitter:image:width: "{{ image.width }}"
+  twitter:image:height: "{{ image.height }}"
+
+# -----------------------------------------------------------------------------
+# Specification
+# -----------------------------------------------------------------------------
+
+# Card size and layers
+size: { width: 1200, height: 630 }
+layers:
+  # Background
+  - background:
+      image: *background_image
+      color: *background_color
+
+  # # Page icon
+  # - size: { width: 630, height: 630 }
+  #   offset: { x: 570, y: 0 }
+  #   icon:
+  #     value: *page_icon
+  #     color: "#00000033"
+
+  # Logo
+  - size: { width: 64, height: 64 }
+    offset: { x: 64, y: 64 }
+    background:
+      image: *logo
+
+  # Site name
+  - size: { width: 768, height: 42 }
+    offset: { x: 160, y: 78 }
+    typography:
+      content: Activism Toolbox
+      color: *color
+      font:
+        family: Bagnard
+        style: Bold
+
+  # Page title
+  - size: { width: 864, height: 256 }
+    offset: { x: 160, y: 256 }
+    typography:
+      content: *page_title
+      align: start
+      color: *color
+      line:
+        amount: 3
+        height: 1.5
+      font:
+        family: *title_font_family
+        style: *title_font_style
+
+  # # Page description
+  # - size: { width: 864, height: 96 }
+  #   offset: { x: 64, y: 480 }
+  #   typography:
+  #     content: *page_description
+  #     align: start
+  #     color: *color
+  #     line:
+  #       amount: 3
+  #       height: 1.5
+  #     font:
+  #       family: *font_family
+  #       style: Regular


### PR DESCRIPTION
- Social cards for the toolbox are still having issues, this makes them a bit better until we have proper previews.
- Fixes "Activism" missing in the navbar on some non-main-site article pages
- Updates outdated author bios
- Removes Kevin from staff list on about page