### PR TITLE
fix: update generate-members.py API URL and improve language handling in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -101,13 +101,13 @@ if [ "$language" == "he" ]; then
 fi
 
 # Set font if russian or chinese
-if [[ "ru zh-Hant zh-TW" =~ $language ]]; then
+if [[ $language =~ ^(ru|zh-Hant|zh-TW)$ ]]; then
   export BUILD_THEME_FONT_CODE="Noto Sans TC"
   export BUILD_THEME_FONT_TEXT="Noto Sans TC"
 fi
 
 # Set stylesheet if hebrew or russian or chinese
-if [[ "he ru zh-Hant zh-TW" =~ $language ]]; then
+if [[ $language =~ ^(he|ru|zh-Hant|zh-TW)$ ]]; then
   export TRANSLATION_STYLESHEET="assets/stylesheets/lang-$language.css?v=20240410"
 fi
 

--- a/tools/generate-members.py
+++ b/tools/generate-members.py
@@ -1,4 +1,3 @@
-
 import requests
 import os
 
@@ -13,7 +12,6 @@ members = members_data['members']
 
 html_output = ""
 for member in members:
-  username = member['username']
   html_output += f'<a href="{member["url"]}" target="_blank" title="@{member["username"]}" class="mdx-donors__item"><img loading="lazy" src="{member["avatar"]}"></a>'
 
 # Append the count of private members

--- a/tools/generate-members.py
+++ b/tools/generate-members.py
@@ -1,9 +1,12 @@
+
 import requests
 import os
 
 # Fetch members from the API
-members_api_url = os.getenv('MEMBERS_API_URL', 'https://ghost.privacyguides.org/cache/members.json')
-members_response = requests.get(members_api_url)
+members_api_url = os.getenv('MEMBERS_API_URL', 'https://privacyguides.org/cache/members.json')
+members_response = requests.get(members_api_url, timeout=10)
+members_response.raise_for_status()
+
 members_data = members_response.json()[0]
 
 members = members_data['members']
@@ -11,7 +14,7 @@ members = members_data['members']
 html_output = ""
 for member in members:
   username = member['username']
-  html_output += f'<a href="{member['url']}" target="_blank" title="@{member['username']}" class="mdx-donors__item"><img loading="lazy" src="{member['avatar']}"></a>'
+  html_output += f'<a href="{member["url"]}" target="_blank" title="@{member["username"]}" class="mdx-donors__item"><img loading="lazy" src="{member["avatar"]}"></a>'
 
 # Append the count of private members
 if members_data['unaccounted'] > 0:


### PR DESCRIPTION

- run.sh
  - Fixed language regex checks to use strict pattern matching for Russian (ru), Traditional Chinese (zh-Hant/zh-TW), and Hebrew (he) to avoid false positives.

- tools/generate-members.py
  - Updated `MEMBERS_API_URL` to `https://privacyguides.org/cache/members.json` because the previous ghost subdomain is no longer available.
  - Added `timeout=10` and `raise_for_status()` to prevent hanging on failed requests.
  - Corrected f-string syntax to safely reference dictionary keys.
