### PR TITLE
Add CloakBin to Pastebins page

### DIFF
--- a/docs/pastebins.md
+++ b/docs/pastebins.md
@@ -41,6 +41,19 @@ cover: pastebins.webp
 
 </div>
 
+## CloakBin
+
+<div class="admonition recommendation" markdown>
+
+**CloakBin** is an open-source, zero-knowledge encrypted pastebin. All encryption (AES-256-GCM) happens client-side in the browser before data reaches the server. The decryption key is stored in the URL fragment (`#key`), which browsers never send to servers. Supports burn-after-reading, password protection, custom expiry, and syntax highlighting for 40+ languages.
+
+[:octicons-home-16: Homepage](https://cloakbin.com){ .md-button .md-button--primary }
+[:octicons-code-16:](https://github.com/Ishannaik/CloakBin){ .card-link title="Source Code" }
+
+</div>
+
+
+
 ## Criteria
 
 **Please note we are not affiliated with any of the projects we recommend.** In addition to [our standard criteria](about/criteria.md), we have developed a clear set of requirements to allow us to provide objective recommendations. We suggest you familiarize yourself with this list before choosing to use a project, and conduct your own research to ensure it's the right choice for you.

--- a/docs/pastebins.md
+++ b/docs/pastebins.md
@@ -45,7 +45,7 @@ cover: pastebins.webp
 
 <div class="admonition recommendation" markdown>
 
-**CloakBin** is an open-source, zero-knowledge encrypted pastebin. All encryption (AES-256-GCM) happens client-side in the browser before data reaches the server. The decryption key is stored in the URL fragment (`#key`), which browsers never send to servers. Supports burn-after-reading, password protection, custom expiry, and syntax highlighting for 40+ languages.
+**CloakBin** is an open-source, zero-knowledge encrypted pastebin. All encryption (AES-256-GCM) happens client-side in the browser before data reaches the server. The decryption key is stored in the URL fragment (`#key`), which browsers never send to servers. Supports burn-after-reading, password protection, custom expiry, and syntax highlighting for many programming languages.
 
 [:octicons-home-16: Homepage](https://cloakbin.com){ .md-button .md-button--primary }
 [:octicons-code-16:](https://github.com/Ishannaik/CloakBin){ .card-link title="Source Code" }


### PR DESCRIPTION
List of changes proposed in this PR:

- Add CloakBin to the Pastebins recommendation page

CloakBin is an open-source, zero-knowledge encrypted pastebin that meets all minimum requirements:

- **Open source**: [github.com/Ishannaik/CloakBin](https://github.com/Ishannaik/CloakBin)
- **Client-side encryption before server transmission**: AES-256-GCM encryption runs entirely in the browser; the server only stores ciphertext. The decryption key stays in the URL fragment (`#key`), which browsers never send to servers.
- **Password-protected files**: Optional password protection adds a second layer on top of the URL fragment key

Additional features: burn-after-reading, custom expiry (1 hour to permanent), syntax highlighting for 40+ languages, no account required.

**Conflict of interest disclosure:** I am the developer of CloakBin.