### PR TITLE
update!: Add the Apple Health app to Menstrual Tracking apps

### DIFF
--- a/docs/health-and-wellness.md
+++ b/docs/health-and-wellness.md
@@ -62,6 +62,26 @@ Popular menstrual trackers like [Flo](https://techcrunch.com/2021/01/13/flo-gets
 
 </div>
 
+### Apple Health
+
+<div class="admonition recommendation" markdown>
+
+![Apple logo](assets/img/health-and-wellness/apple-health.webp#only-light){ align=right }![Apple logo](assets/img/health-and-wellness/apple-health-dark.webp#only-dark){ align=right }
+
+Apple Health is one of the default apps installed on iOS devices. It includes many health and wellness features (see [Health Records](#apple-health-records)), including menstrual cycle tracking. It also uses gender-neutral language. Apple Health always uses end-to-end encryption when syncing across multiple devices.
+
+[:octicons-home-16: Homepage](https://apple.com/health){ .md-button .md-button--primary }
+[:octicons-eye-16:](https://apple.com/legal/privacy/consumer-health-personal-data/en-ww){ .card-link title="Privacy Policy" }
+
+<details class="downloads" markdown>
+<summary>Downloads</summary>
+
+- [:simple-appstore: App Store](https://apps.apple.com/app/apple-health/id1242545199)
+
+</details>
+
+</div>
+
 ## Fitness Trackers
 
 These general purpose apps can do everything from counting steps and tracking sleep to measuring your heartbeat.
@@ -121,7 +141,7 @@ These apps help you collect and manage personal health data and share it with he
 
 ![Apple logo](assets/img/health-and-wellness/apple-health.webp#only-light){ align=right }![Apple logo](assets/img/health-and-wellness/apple-health-dark.webp#only-dark){ align=right }
 
-**Apple Health Records** is a built-in feature within [Apple Health](https://apple.com/health) that allows you to view, store, and share your health records. It shares the security and privacy features of [Apple Fitness](#apple-fitness).
+**Apple Health Records** is a built-in feature within [Apple Health](#apple-health) that allows you to view, store, and share your health records.
 
 [:octicons-home-16: Homepage](https://apple.com/health){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://apple.com/legal/privacy/consumer-health-personal-data/en-ww){ .card-link title="Privacy Policy" }

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -473,6 +473,7 @@ For encrypting your OS drive, we typically recommend using the encryption tool y
 
 - ![Drip logo](assets/img/health-and-wellness/drip.png){ .twemoji loading=lazy } [Drip](health-and-wellness.md#drip)
 - ![Euki logo](assets/img/health-and-wellness/euki.svg){ .twemoji loading=lazy } [Euki](health-and-wellness.md#euki)
+- ![Apple Health logo](assets/img/health-and-wellness/apple-health.webp#only-light){ .twemoji loading=lazy } ![Apple Health logo](assets/img/health-and-wellness/apple-health-dark.webp#only-dark){ .twemoji loading=lazy } [Apple Health](health-and-wellness.md#apple-health)
 - ![Apple Fitness logo](assets/img/health-and-wellness/apple-fitness.webp){ .twemoji loading=lazy } [Apple Fitness](health-and-wellness.md#apple-fitness)
 - ![Gadgetbridge logo](assets/img/health-and-wellness/gadgetbridge.svg#only-light){ .twemoji loading=lazy }![Gadgetbridge logo](assets/img/health-and-wellness/gadgetbridge-dark.svg#only-dark){ .twemoji loading=lazy } [Gadgetbridge](health-and-wellness.md#gadgetbridge)
 - ![Apple Health logo](assets/img/health-and-wellness/apple-health.webp#only-light){ .twemoji loading=lazy } ![Apple Health logo](assets/img/health-and-wellness/apple-health-dark.webp#only-dark){ .twemoji loading=lazy } [Apple Health Records](health-and-wellness.md#apple-health-records)


### PR DESCRIPTION
List of changes proposed in this PR:

- Added Apple Health under Menstrual Tracking apps.
- Updated descriptions of Apple Fitness and Apple Health Records to fit with the new addition.

Apple Health Records and Apple Fitness are recommended apps in Health and Wellness. I think the Apple Health app in general is worth adding to the menstrual tracking list. I mentioned that it includes many other health and wellness features. As far as I can tell, it's gender-neutral. It's possible that I might've missed something in its information sections (information about menstrual cycles and the like) though.

Relevant discussion: https://discuss.privacyguides.net/t/add-apple-health-to-menstrual-trackers/36356
<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

I use it as a nonbinary person who has periods. Does that count?
-->
