### PR TITLE
update: change links and domain from ente.io to ente.com

### DIFF
--- a/docs/multi-factor-authentication.md
+++ b/docs/multi-factor-authentication.md
@@ -38,7 +38,7 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.ente.auth)
 - [:simple-appstore: App Store](https://apps.apple.com/app/id6444121398)
 - [:simple-github: GitHub](https://github.com/ente-io/ente/releases?q=auth)
-- [:octicons-browser-16: Web](https://auth.ente.com)
+- [:octicons-browser-16: Web](https://auth.ente.io)
 
 </details>
 

--- a/docs/multi-factor-authentication.md
+++ b/docs/multi-factor-authentication.md
@@ -29,7 +29,7 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 
 [:octicons-home-16: Homepage](https://ente.com/auth){ .md-button .md-button--primary }
 [:octicons-eye-16:](https://ente.com/privacy){ .card-link title="Privacy Policy" }
-[:octicons-info-16:](https://help.ente.com/auth){ .card-link title="Documentation" }
+[:octicons-info-16:](https://ente.com/help/auth){ .card-link title="Documentation" }
 [:octicons-code-16:](https://github.com/ente-io/ente/tree/main/auth#readme){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>

--- a/docs/multi-factor-authentication.md
+++ b/docs/multi-factor-authentication.md
@@ -27,8 +27,7 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 
 **Ente Auth** is a free and open-source app which stores and generates TOTP tokens. It can be used with an online account to back up and sync your tokens across your devices (and access them via a web interface) in a secure, end-to-end encrypted fashion. It can also be used offline on a single device with no account necessary.
 
-[:octicons-home-16: Homepage](https://ente.com/auth){ .md-button .md-button--primary }
-[:octicons-eye-16:](https://ente.com/privacy){ .card-link title="Privacy Policy" }
+[:octicons-home-16: Homepage](https://ente.com/auth){ .md-button .[:octicons-eye-16:](https://ente.com/privacy){ .card-link title="Privacy Policy" }
 [:octicons-info-16:](https://ente.com/help/auth){ .card-link title="Documentation" }
 [:octicons-code-16:](https://github.com/ente-io/ente/tree/main/auth#readme){ .card-link title="Source Code" }
 

--- a/docs/multi-factor-authentication.md
+++ b/docs/multi-factor-authentication.md
@@ -27,9 +27,9 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 
 **Ente Auth** is a free and open-source app which stores and generates TOTP tokens. It can be used with an online account to back up and sync your tokens across your devices (and access them via a web interface) in a secure, end-to-end encrypted fashion. It can also be used offline on a single device with no account necessary.
 
-[:octicons-home-16: Homepage](https://ente.io/auth){ .md-button .md-button--primary }
-[:octicons-eye-16:](https://ente.io/privacy){ .card-link title="Privacy Policy" }
-[:octicons-info-16:](https://help.ente.io/auth){ .card-link title="Documentation" }
+[:octicons-home-16: Homepage](https://ente.com/auth){ .md-button .md-button--primary }
+[:octicons-eye-16:](https://ente.com/privacy){ .card-link title="Privacy Policy" }
+[:octicons-info-16:](https://help.ente.com/auth){ .card-link title="Documentation" }
 [:octicons-code-16:](https://github.com/ente-io/ente/tree/main/auth#readme){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
@@ -38,13 +38,13 @@ We highly recommend that you use mobile TOTP apps instead of desktop alternative
 - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.ente.auth)
 - [:simple-appstore: App Store](https://apps.apple.com/app/id6444121398)
 - [:simple-github: GitHub](https://github.com/ente-io/ente/releases?q=auth)
-- [:octicons-browser-16: Web](https://auth.ente.io)
+- [:octicons-browser-16: Web](https://auth.ente.com)
 
 </details>
 
 </div>
 
-The server-side source code and infrastructure which underpins Ente Auth (if used with an online account) underwent an audit by [Cure53](https://ente.io/blog/cern-audit) in October 2025.
+The server-side source code and infrastructure which underpins Ente Auth (if used with an online account) underwent an audit by [Cure53](https://ente.com/blog/cern-audit) in October 2025.
 
 ## Aegis Authenticator (Android)
 

--- a/docs/photo-management.md
+++ b/docs/photo-management.md
@@ -36,7 +36,7 @@ The free plan offers 10 GB of storage as long as you use the service at least o
 - [:fontawesome-brands-windows: Windows](https://ente.com/download)
 - [:simple-apple: macOS](https://ente.com/download)
 - [:simple-linux: Linux](https://ente.com/download)
-- [:octicons-browser-16: Web](https://web.ente.com)
+- [:octicons-browser-16: Web](https://web.ente.io)
 
 </details>
 

--- a/docs/photo-management.md
+++ b/docs/photo-management.md
@@ -21,9 +21,9 @@ Most cloud **photo management solutions** like Google Photos, Flickr, and Amazon
 
 The free plan offers 10 GB of storage as long as you use the service at least once a year.
 
-[:octicons-home-16: Homepage](https://ente.io){ .md-button .md-button--primary }
-[:octicons-eye-16:](https://ente.io/privacy){ .card-link title="Privacy Policy" }
-[:octicons-info-16:](https://ente.io/faq){ .card-link title="Documentation" }
+[:octicons-home-16: Homepage](https://ente.com){ .md-button .md-button--primary }
+[:octicons-eye-16:](https://ente.com/privacy){ .card-link title="Privacy Policy" }
+[:octicons-info-16:](https://ente.com/faq){ .card-link title="Documentation" }
 [:octicons-code-16:](https://github.com/ente-io/ente){ .card-link title="Source Code" }
 
 <details class="downloads" markdown>
@@ -32,17 +32,17 @@ The free plan offers 10 GB of storage as long as you use the service at least o
 - [:simple-googleplay: Google Play](https://play.google.com/store/apps/details?id=io.ente.photos)
 - [:simple-appstore: App Store](https://apps.apple.com/app/id1542026904)
 - [:simple-github: GitHub](https://github.com/ente-io/ente/releases?q=photos)
-- [:simple-android: Android](https://ente.io/download)
-- [:fontawesome-brands-windows: Windows](https://ente.io/download)
-- [:simple-apple: macOS](https://ente.io/download)
-- [:simple-linux: Linux](https://ente.io/download)
-- [:octicons-browser-16: Web](https://web.ente.io)
+- [:simple-android: Android](https://ente.com/download)
+- [:fontawesome-brands-windows: Windows](https://ente.com/download)
+- [:simple-apple: macOS](https://ente.com/download)
+- [:simple-linux: Linux](https://ente.com/download)
+- [:octicons-browser-16: Web](https://web.ente.com)
 
 </details>
 
 </div>
 
-The server-side source code and infrastructure which underpins Ente Photos underwent an audit by [Cure53](https://ente.io/blog/cern-audit) in October 2025. Previous audits were completed by [Cure53](https://ente.io/blog/cryptography-audit) in March 2023 and by [Fallible](https://ente.io/reports/Fallible-Audit-Report-19-04-2023.pdf) in April 2023.
+The server-side source code and infrastructure which underpins Ente Photos underwent an audit by [Cure53](https://ente.com/blog/cern-audit) in October 2025. Previous audits were completed by [Cure53](https://ente.com/blog/cryptography-audit) in March 2023 and by [Fallible](https://ente.com/reports/Fallible-Audit-Report-19-04-2023.pdf) in April 2023.
 
 ## Criteria
 

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -171,8 +171,8 @@ Tool recommendations in other categories of the website also provide a self-host
 
     ---
 
-    [:octicons-home-16:](https://ente.io){ .card-link title="Homepage" }
-    [:octicons-info-16:](https://help.ente.io/self-hosting){ .card-link title="Admin Documentation" }
+    [:octicons-home-16:](https://ente.com){ .card-link title="Homepage" }
+    [:octicons-info-16:](https://ente.com/help/self-hosting/){ .card-link title="Admin Documentation" }
     [:octicons-code-16:](https://github.com/ente-io/ente){ .card-link title="Source Code" }
 
 - ![CryptPad logo](../assets/img/document-collaboration/cryptpad.svg){ .twemoji } [**CryptPad**](../document-collaboration.md#cryptpad)


### PR DESCRIPTION
List of changes proposed in this PR:

- Changed ente.io links to the new domain ente.com, except where ente.io is still used

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
