### PR TITLE
Remove sentence about the user's Premium account being tied to use of Brave Search

### DIFF
--- a/docs/search-engines.md
+++ b/docs/search-engines.md
@@ -55,8 +55,6 @@ Brave Search is the default search engine for the [Brave Browser](desktop-browse
 
 </div>
 
-If you use Brave Search while logged in to a Premium account, there is a risk of Brave correlating search queries with your account.
-
 We recommend you disable [Anonymous usage metrics](https://search.brave.com/help/usage-metrics) as it is enabled by default and can be disabled within settings.
 
 ### DuckDuckGo


### PR DESCRIPTION
I'm proposing removing the following sentence: `If you use Brave Search while logged in to a Premium account, there is a risk of Brave correlating search queries with your account.` from https://www.privacyguides.org/en/search-engines/#recommended-providers.

I also raised this as a discussion topic on https://discuss.privacyguides.net/t/inaccurate-statement-about-brave-search-on-recommended-search-engines/37612 and haven't heard any push back.

Brave uses blind tokens to decouple payment identity from usage. When you sign up for [Brave Search Premium](https://search.brave.com/help/premium) and use Brave Search, Brave just comes to know that you're a Premium user (it has to, to offer the Premium experience) but not who you are. The use of blind tokens in Brave browser for Premium is documented [here](https://github.com/brave/brave-core/blob/530d91c962b1ebdfba57d712607ba144b467c3ac/docs/premium_account_privacy.md) with links to open-source code implementing it. Brave has no way of correlating your search queries with your Premium account; that would be a fundamental break down of the privacy guarantee of Brave Search.

Source: I lead privacy at Brave browser.

<!--
Please use a descriptive title for your PR, it will be included in our changelog!

If you are making changes that you have a conflict of interest with, you MUST
disclose this as well (this does not disqualify your PR by any means):

Conflict of interest contributions involve contributing about yourself,
family, friends, clients, employers, or your financial and other relationships.
ANY external relationship can trigger a conflict of interest.
-->
