### PR TITLE
update: Remove mention of removed Firefox PPA setting

### DIFF
--- a/docs/desktop-browsers.md
+++ b/docs/desktop-browsers.md
@@ -197,12 +197,6 @@ Additionally, the Mozilla Accounts service collects [some technical data](https:
 1. Open your [profile settings on accounts.firefox.com](https://accounts.firefox.com/settings#data-collection)
 2. Uncheck **Data Collection and Use** > **Help improve Firefox Accounts**
 
-##### Website Advertising Preferences
-
-- [ ] Uncheck **Allow websites to perform privacy-preserving ad measurement**
-
-With the release of Firefox 128, a new setting for [privacy-preserving attribution](https://support.mozilla.org/kb/privacy-preserving-attribution) (PPA) has been added and [enabled by default](https://blog.privacyguides.org/2024/07/14/mozilla-disappoints-us-yet-again-2). PPA allows advertisers to use your web browser to measure the effectiveness of web campaigns, instead of using traditional JavaScript-based tracking. We consider this behavior to be outside the scope of a user agent's responsibilities, and the fact that it is disabled by default in Arkenfox is an additional indicator for disabling this feature.
-
 ##### HTTPS-Only Mode
 
 - [x] Select **Enable HTTPS-Only Mode in all windows**


### PR DESCRIPTION
The linked article states that privacy-preserving attribution is no longer included in Firefox:

> Privacy-preserving attribution (PPA) was an experimental feature in Firefox version 128 which was never activated and was later removed.

https://support.mozilla.org/en-US/kb/privacy-preserving-attribution
