### PR TITLE
update: Clarify software packaging for recommended Linux distros

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -8,7 +8,7 @@ cover: desktop.webp
 
 - [:material-account-cash: Surveillance Capitalism](basics/common-threats.md#surveillance-as-a-business-model){ .pg-brown }
 
-Linux distributions are commonly recommended for privacy protection and software freedom. If you don't already use Linux, below are some distributions we suggest trying out, as well as some general privacy and security improvement tips that are applicable to many Linux distributions. Please note that some of our recommended software may not be packaged for your Linux distribution of choosing.
+Linux distributions are commonly recommended for privacy protection and software freedom. If you don't already use Linux, below are some distributions we suggest trying out, as well as some general privacy and security improvement tips that are applicable to many Linux distributions. Please note that some of our recommended software may not be packaged for your Linux distribution of choice.
 
 - [General Linux Overview :material-arrow-right-drop-circle:](os/linux-overview.md)
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -8,7 +8,7 @@ cover: desktop.webp
 
 - [:material-account-cash: Surveillance Capitalism](basics/common-threats.md#surveillance-as-a-business-model){ .pg-brown }
 
-Linux distributions are commonly recommended for privacy protection and software freedom. If you don't already use Linux, below are some distributions we suggest trying out, as well as some general privacy and security improvement tips that are applicable to many Linux distributions.
+Linux distributions are commonly recommended for privacy protection and software freedom. If you don't already use Linux, below are some distributions we suggest trying out, as well as some general privacy and security improvement tips that are applicable to many Linux distributions. Please note that some of our recommended software may not be packaged for your Linux distribution of choosing.
 
 - [General Linux Overview :material-arrow-right-drop-circle:](os/linux-overview.md)
 


### PR DESCRIPTION
Added a note about software packaging for Linux distributions.

List of changes proposed in this PR:

- Simply adds a note that some of the recommended software on the site are not packaged by default by certain Linux distributions. Based on the site recommendation discussion in: https://discuss.privacyguides.net/t/create-a-warning-for-opensuse-and-nixos-due-to-low-package-availability/38249
