### PR TITLE
update: Nitrokey section on OTP secrets

### DIFF
--- a/docs/security-keys.md
+++ b/docs/security-keys.md
@@ -102,7 +102,7 @@ Nitrokey models can be configured using the [Nitrokey app](https://nitrokey.com/
 <div class="admonition warning" markdown>
 <p class="admonition-title">Warning</p>
 
-Excluding the Nitrokey 3, Nitrokeys which support HOTP and TOTP do not have encrypted storage, making them vulnerable to physical attacks.
+Starting with Nitrokey 3, HOTP and TOTP secrets are additionally encrypted at rest. Older Nitrokey devices like Nitrokey Pro 2 and Nitrokey Storage 2 did not encrypt OTP secrets at rest, which makes the OTP secrets on these devices potentially vulnerable to physical attacks.
 
 </div>
 


### PR DESCRIPTION
List of changes proposed in this PR:

- Update the phrasing regarding OTP secrets to be more specific about device specific OTP encryption details. 

Following user feedback and [some user confusion about Nitrokeys](https://discuss.grapheneos.org/d/17614-which-u2f-key-is-the-most-secure/7) that seems to have been caused by the current wording.

Disclosure: Nitrokey employee (: