### PR TITLE
update: remove spam link

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -89,8 +89,6 @@ Tresorit has received a number of independent security audits:
 
 [^1]: [ISO/IEC 27001](https://en.wikipedia.org/wiki/ISO/IEC_27001):2013 compliance relates to the company's [information security management system](https://en.wikipedia.org/wiki/Information_security_management) and covers the sales, development, maintenance and support of their cloud services.
 
-They have also received the Digital Trust Label, a certification from the [Swiss Digital Initiative](https://efd.admin.ch/en/swiss-digital-initiative-en) which requires passing [35 criteria](https://swiss-digital-initiative.org/criteria) related to security, privacy, and reliability.
-
 ## Peergos
 
 <div class="admonition recommendation" markdown>


### PR DESCRIPTION
Summary:

- Replaced "35 criteria" link to `swiss-digital-initiative.org` with link to `web.archive.org`, as the old page shows spammy sports betting content.
- Removed link to Swiss Digital Initiative page from `efd.admin.ch` because it 404s.
- Added new relevant link about Digital Trust Label from SGS, the company the SDI transferred the Digital Trust Label to ([Starting the Next Chapter for the Digital Trust Label](https://www.sgs.com/en/news/2025/01/starting-the-next-chapter-for-the-digital-trust-label)).
