### PR TITLE
fix: Yubico U2F on Linux guide link

### DIFF
--- a/docs/basics/multi-factor-authentication.md
+++ b/docs/basics/multi-factor-authentication.md
@@ -140,7 +140,7 @@ If the hostname of your system changes (such as due to DHCP), you would be unabl
 
 </div>
 
-The `pam_u2f` module on Linux can provide two-factor authentication for logging in on most popular Linux distributions. If you have a hardware security key that supports U2F, you can set up MFA authentication for your login. Yubico has a guide [Ubuntu Linux Login Guide - U2F](https://support.yubico.com/hc/articles/360016649099-Ubuntu-Linux-Login-Guide-U2F) which should work on any distribution. The package manager commands—such as `apt-get`—and package names may however differ. This guide does **not** apply to Qubes OS.
+The `pam_u2f` module on Linux can provide two-factor authentication for logging in on most popular Linux distributions. If you have a hardware security key that supports U2F, you can set up MFA authentication for your login. Yubico has a guide [Ubuntu Linux Login Guide - U2F](https://support.yubico.com/s/article/Ubuntu-Linux-login-guide-U2F) which should work on any distribution. The package manager commands—such as `apt-get`—and package names may however differ. This guide does **not** apply to Qubes OS.
 
 ### Qubes OS
 


### PR DESCRIPTION
Updated the link to the Yubico Ubuntu Linux Login Guide for U2F.
